### PR TITLE
Fix CI workflows and E2E tests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,12 @@
+name: 'Setup Project'
+description: 'Setup pnpm, Node.js, and install dependencies'
+runs:
+  using: 'composite'
+  steps:
+    - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+    - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'pnpm'
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check CI result
         if: steps.wait-for-ci.outputs.conclusion != 'success'
         run: |
-          echo "❌ CI workflow did not succeed: ${{ steps.wait-for-ci.outputs.conclusion }}"
+          echo "CI workflow did not succeed: ${{ steps.wait-for-ci.outputs.conclusion }}"
           exit 1
 
   deploy-web:
@@ -46,12 +46,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm build
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
@@ -70,17 +65,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+      - uses: ./.github/actions/setup
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
       - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
-      - run: pnpm install --frozen-lockfile
       - run: pnpm build:mobile
       - name: Build Debug APK
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm lint
 
   typecheck:
@@ -33,12 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm exec tsc --noEmit
 
   unit:
@@ -46,12 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm test:coverage
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
@@ -67,12 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm build
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -111,12 +91,7 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - name: Download build artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -133,15 +108,14 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
-  e2e-comprehensive:
-    name: E2E Comprehensive - All Tests - ${{ matrix.project }}
+  e2e-matrix:
+    name: E2E Matrix - ${{ matrix.project }}
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
       fail-fast: false
       matrix:
-        # Representative devices from each category that run all test suites
         project:
           - 'Desktop Chrome'
           - 'iPhone 12 Portrait'
@@ -154,14 +128,18 @@ jobs:
           - 'Samsung Galaxy Fold Folded Landscape'
           - 'Samsung Galaxy Fold Unfolded Portrait'
           - 'Samsung Galaxy Fold Unfolded Landscape'
+          - 'Desktop Firefox'
+          - 'Desktop Safari'
+          - 'iPhone 12 Pro Portrait'
+          - 'iPhone 13 Portrait'
+          - 'iPhone 14 Portrait'
+          - 'iPad Pro 12.9 Portrait'
+          - 'Galaxy S21 Portrait'
+          - 'Surface Duo Portrait'
+          - 'Surface Duo Landscape'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - name: Download build artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -174,7 +152,7 @@ jobs:
         run: |
           PROJECT_SLUG=$(echo "${{ matrix.project }}" | sed 's/ /-/g')
           echo "project_slug=${PROJECT_SLUG}" >> $GITHUB_OUTPUT
-      - name: Run E2E comprehensive tests
+      - name: Run E2E matrix tests
         run: pnpm exec playwright test --project="${{ matrix.project }}" --workers=1 --reporter=junit,line
         env:
           PLAYWRIGHT_JUNIT_OUTPUT_NAME: junit-${{ steps.slug.outputs.project_slug }}.xml
@@ -182,26 +160,26 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
-          name: e2e-comprehensive-junit-${{ steps.slug.outputs.project_slug }}
+          name: e2e-matrix-junit-${{ steps.slug.outputs.project_slug }}
           path: junit-${{ steps.slug.outputs.project_slug }}.xml
           retention-days: 7
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
-          name: e2e-comprehensive-reports-${{ steps.slug.outputs.project_slug }}
+          name: e2e-matrix-reports-${{ steps.slug.outputs.project_slug }}
           path: playwright-report/
           retention-days: 7
 
-  e2e-comprehensive-collector:
-    name: E2E Comprehensive - Collector
+  e2e-matrix-collector:
+    name: E2E Matrix - Collector
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [e2e-comprehensive]
+    needs: [e2e-matrix]
     steps:
       - name: Download all JUnit artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          pattern: e2e-comprehensive-junit-*
+          pattern: e2e-matrix-junit-*
           path: junit-results/
           merge-multiple: true
       - name: Combine JUnit reports
@@ -226,152 +204,32 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
-          name: e2e-comprehensive-junit-combined
+          name: e2e-matrix-junit-combined
           path: combined-junit/
           retention-days: 7
-      - name: Check E2E comprehensive results
+      - name: Check E2E matrix results
         run: |
-          echo "E2E Comprehensive Test Results:"
-          echo "Matrix job result: ${{ needs.e2e-comprehensive.result }}"
+          echo "E2E Matrix Test Results:"
+          echo "Matrix job result: ${{ needs.e2e-matrix.result }}"
 
           # Check if any matrix job failed
-          if [[ "${{ needs.e2e-comprehensive.result }}" == "failure" ]]; then
-            echo "❌ One or more E2E comprehensive tests failed"
+          if [[ "${{ needs.e2e-matrix.result }}" == "failure" ]]; then
+            echo "❌ One or more E2E matrix tests failed"
             echo "Check individual matrix job results for details"
             exit 1
-          elif [[ "${{ needs.e2e-comprehensive.result }}" == "cancelled" ]]; then
-            echo "⚠️ E2E comprehensive tests were cancelled"
+          elif [[ "${{ needs.e2e-matrix.result }}" == "cancelled" ]]; then
+            echo "⚠️ E2E matrix tests were cancelled"
             exit 1
           fi
 
-          echo "✅ All E2E comprehensive matrix tests passed"
-
-  e2e-device-responsive:
-    name: E2E Device Responsive - ${{ matrix.project }}
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: [build]
-    strategy:
-      fail-fast: false
-      matrix:
-        # All device profiles for responsive testing
-        project:
-          - 'Desktop Chrome'
-          - 'Desktop Firefox'
-          - 'Desktop Safari'
-          - 'iPhone 12 Portrait'
-          - 'iPhone 12 Pro Portrait'
-          - 'iPhone 13 Portrait'
-          - 'iPhone 14 Portrait'
-          - 'iPhone 12 Landscape'
-          - 'iPad Pro 11 Portrait'
-          - 'iPad Pro 11 Landscape'
-          - 'iPad Pro 12.9 Portrait'
-          - 'Pixel 5 Portrait'
-          - 'Pixel 5 Landscape'
-          - 'Galaxy S21 Portrait'
-          - 'Samsung Galaxy Fold Folded'
-          - 'Samsung Galaxy Fold Unfolded'
-          - 'Surface Duo Portrait'
-          - 'Surface Duo Landscape'
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - name: Download build artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: dist
-          path: dist/
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium webkit firefox
-      - name: Set project slug
-        id: slug
-        run: |
-          PROJECT_SLUG=$(echo "${{ matrix.project }}" | sed 's/ /-/g')
-          echo "project_slug=${PROJECT_SLUG}" >> $GITHUB_OUTPUT
-      - name: Run device-responsive tests
-        run: pnpm exec playwright test --project="${{ matrix.project }}" --workers=1 --reporter=junit,line
-        env:
-          PLAYWRIGHT_JUNIT_OUTPUT_NAME: junit-device-responsive-${{ steps.slug.outputs.project_slug }}.xml
-      - name: Upload JUnit test results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: always()
-        with:
-          name: e2e-device-responsive-junit-${{ steps.slug.outputs.project_slug }}
-          path: junit-device-responsive-${{ steps.slug.outputs.project_slug }}.xml
-          retention-days: 7
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: failure()
-        with:
-          name: e2e-device-responsive-reports-${{ steps.slug.outputs.project_slug }}
-          path: playwright-report/
-          retention-days: 7
-
-  e2e-device-responsive-collector:
-    name: E2E Device Responsive - Collector
-    runs-on: ubuntu-latest
-    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [e2e-device-responsive]
-    steps:
-      - name: Download all JUnit artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: e2e-device-responsive-junit-*
-          path: junit-results/
-          merge-multiple: true
-      - name: Combine JUnit reports
-        run: |
-          mkdir -p combined-junit
-          # Check if any XML files exist
-          if [ -d "junit-results" ] && compgen -G "junit-results/*.xml" > /dev/null; then
-            echo '<?xml version="1.0" encoding="UTF-8"?>' > combined-junit/junit-combined.xml
-            echo '<testsuites>' >> combined-junit/junit-combined.xml
-            for file in junit-results/*.xml; do
-              # Extract testsuite elements (skip XML declaration and testsuites wrapper)
-              sed -n '/<testsuite[> ]/,/<\/testsuite>/p' "$file" >> combined-junit/junit-combined.xml
-            done
-            echo '</testsuites>' >> combined-junit/junit-combined.xml
-            echo "✅ Combined JUnit reports successfully"
-            echo "Reports found:"
-            ls -la junit-results/
-          else
-            echo "⚠️ No JUnit reports found to combine"
-          fi
-      - name: Upload combined JUnit results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: always()
-        with:
-          name: e2e-device-responsive-junit-combined
-          path: combined-junit/
-          retention-days: 7
-      - name: Check E2E device-responsive results
-        run: |
-          echo "E2E Device Responsive Test Results:"
-          echo "Matrix job result: ${{ needs.e2e-device-responsive.result }}"
-
-          # Check if any matrix job failed
-          if [[ "${{ needs.e2e-device-responsive.result }}" == "failure" ]]; then
-            echo "❌ One or more E2E device-responsive tests failed"
-            echo "Check individual matrix job results for details"
-            exit 1
-          elif [[ "${{ needs.e2e-device-responsive.result }}" == "cancelled" ]]; then
-            echo "⚠️ E2E device-responsive tests were cancelled"
-            exit 1
-          fi
-
-          echo "✅ All E2E device-responsive matrix tests passed"
+          echo "✅ All E2E matrix tests passed"
 
   # Collector job that ensures all checks pass
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint, typecheck, unit, build, sonarcloud, e2e-smoke, e2e-comprehensive-collector, e2e-device-responsive-collector]
+    needs: [lint, typecheck, unit, build, sonarcloud, e2e-smoke, e2e-matrix-collector]
     steps:
       - name: Check CI status
         run: |
@@ -401,12 +259,8 @@ jobs:
             echo "❌ E2E smoke tests failed"
             exit 1
           fi
-          if [[ "${{ needs.e2e-comprehensive-collector.result }}" != "success" && "${{ needs.e2e-comprehensive-collector.result }}" != "skipped" ]]; then
-            echo "❌ E2E comprehensive tests failed"
-            exit 1
-          fi
-          if [[ "${{ needs.e2e-device-responsive-collector.result }}" != "success" && "${{ needs.e2e-device-responsive-collector.result }}" != "skipped" ]]; then
-            echo "❌ E2E device-responsive tests failed"
+          if [[ "${{ needs.e2e-matrix-collector.result }}" != "success" && "${{ needs.e2e-matrix-collector.result }}" != "skipped" ]]; then
+            echo "❌ E2E matrix tests failed"
             exit 1
           fi
           echo "✅ All CI checks passed"

--- a/e2e/game.spec.ts
+++ b/e2e/game.spec.ts
@@ -25,12 +25,16 @@ test.describe('Psyduck Panic Game', () => {
     const canvas = page.locator('#gameCanvas');
     await expect(canvas).toBeVisible();
 
-    // Check width attribute is at least 800 (Pixi autoDensity might scale it up)
-    const width = await canvas.getAttribute('width');
-    expect(Number(width)).toBeGreaterThanOrEqual(800);
+    // Check dimensions and aspect ratio (Pixi autoDensity scales backing store)
+    const width = Number(await canvas.getAttribute('width'));
+    const height = Number(await canvas.getAttribute('height'));
 
-    const height = await canvas.getAttribute('height');
-    expect(Number(height)).toBeGreaterThanOrEqual(600);
+    expect(width).toBeGreaterThan(0);
+    expect(height).toBeGreaterThan(0);
+
+    // Allow small rounding errors for aspect ratio check (4:3)
+    const ratio = width / height;
+    expect(Math.abs(ratio - 4 / 3)).toBeLessThan(0.05);
   });
 
   test('should have control buttons', async ({ page }) => {


### PR DESCRIPTION
This PR fixes the CI failures by restoring the missing `.github/actions/setup` composite action, updating the brittle E2E canvas test to be resolution-independent, and consolidating the E2E workflow jobs into a single matrix with correct project names.

---
*PR created automatically by Jules for task [3346561852846970986](https://jules.google.com/task/3346561852846970986) started by @jbdevprimary*