### PR TITLE
fix(ci): install chromium for iPad E2E matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
## Summary

- Fix iPad E2E matrix jobs failing with `browserType.launch: Executable doesn't exist at chromium_headless_shell`
- Root cause: CI workflow installed webkit for iPad projects, but Playwright config uses chromium (default) for iPad custom configs
- Remove `"iPad"` from the webkit install condition — only `"Safari"` and `"iPhone"` projects actually use webkit via Playwright's built-in device descriptors

## Details

The `playwright.config.ts` iPad projects are custom configs specifying viewport/userAgent/etc. manually **without** `defaultBrowserType`, so they default to chromium. The iPhone projects use `devices['iPhone 12']` etc. which include `defaultBrowserType: 'webkit'`.

The CI workflow's browser install step matched `*"iPad"*` alongside `*"Safari"*` and `*"iPhone"*` for webkit installation, but iPad projects need chromium.

## Test plan

- [ ] All 3 iPad matrix jobs pass (iPad Pro 11 Portrait, iPad Pro 11 Landscape, iPad Pro 12.9 Portrait)
- [ ] All other E2E matrix jobs continue to pass
- [ ] Lint, typecheck, unit tests pass

https://claude.ai/code/session_01BpxxZC8JxD2Sr5tDci3jbF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline configuration for E2E testing browser installation, improving build efficiency on certain test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->