### PR TITLE
fix(e2e): skip phone-specific tests on tablets to resolve CI timeout

### DIFF
--- a/e2e/device-responsive.spec.ts
+++ b/e2e/device-responsive.spec.ts
@@ -114,8 +114,14 @@ test.describe('Responsive Device Tests', () => {
 });
 
 test.describe('Phone-Specific Tests', () => {
-  test('should have touch-friendly button sizes on phones', async ({ page, isMobile }) => {
-    test.skip(!isMobile, 'This test is only for mobile devices');
+  test('should have touch-friendly button sizes on phones', async ({
+    page,
+    isMobile,
+    viewport,
+  }) => {
+    // Skip if not mobile or if it's a tablet (width >= 600)
+    const isTablet = viewport && Math.min(viewport.width, viewport.height) >= 600;
+    test.skip(!isMobile || !!isTablet, 'This test is only for mobile phone devices');
 
     await page.goto('/game');
     const startBtn = page.locator('#start-btn');
@@ -140,8 +146,10 @@ test.describe('Phone-Specific Tests', () => {
     }
   });
 
-  test('should handle touch interactions on phones', async ({ page, isMobile }) => {
-    test.skip(!isMobile, 'This test is only for mobile devices');
+  test('should handle touch interactions on phones', async ({ page, isMobile, viewport }) => {
+    // Skip if not mobile or if it's a tablet (width >= 600)
+    const isTablet = viewport && Math.min(viewport.width, viewport.height) >= 600;
+    test.skip(!isMobile || !!isTablet, 'This test is only for mobile phone devices');
 
     await page.goto('/game');
 


### PR DESCRIPTION
The CI/CD workflow "CI" failed because "Phone-Specific Tests" in `e2e/device-responsive.spec.ts` were running on iPad jobs (recently enabled to run on Chromium). These tests timed out, likely due to the mismatch between phone-specific assertions/expectations and the tablet viewport or performance overhead in emulation.

This change modifies the test skip condition to explicitly exclude tablets (viewport min dimension >= 600px) from "Phone-Specific Tests", ensuring they only run on phone-sized devices as intended. Verified locally that iPad tests now skip these specific cases and pass the suite.

---
*PR created automatically by Jules for task [17399039797670659066](https://jules.google.com/task/17399039797670659066) started by @jbdevprimary*