### PR TITLE
fix(ci): use webkit for iPad E2E matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 11 Portrait',
       use: {
+        browserName: 'webkit',
         viewport: { width: 834, height: 1194 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
@@ -114,6 +115,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 12.9 Portrait',
       use: {
+        browserName: 'webkit',
         viewport: { width: 1024, height: 1366 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
@@ -126,6 +128,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 11 Landscape',
       use: {
+        browserName: 'webkit',
         viewport: { width: 1194, height: 834 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',


### PR DESCRIPTION
The CI/CD workflow failed because iPad E2E tests were running on the default browser (Chromium) after a previous fix installed Chromium for them. However, iPad tests are configured with Safari user agents and are best tested on WebKit (Playwright's iOS emulation engine).

This change:
1.  Explicitly sets `browserName: 'webkit'` in `playwright.config.ts` for all three iPad projects (`iPad Pro 11 Portrait`, `iPad Pro 12.9 Portrait`, `iPad Pro 11 Landscape`).
2.  Reverts the CI workflow change to install `webkit` for any project name containing "iPad", ensuring the required browser binary is available.

This ensures iPad tests run on WebKit as intended, providing more accurate emulation and fixing the mismatch that caused CI instability.

---
*PR created automatically by Jules for task [2595741242060945212](https://jules.google.com/task/2595741242060945212) started by @jbdevprimary*