### PR TITLE
fix(ci): use webkit for iPad E2E tests and install correct browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,12 +45,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 11 Portrait',
       use: {
-        viewport: { width: 834, height: 1194 },
-        userAgent:
-          'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
-        deviceScaleFactor: 2,
-        isMobile: true,
-        hasTouch: true,
+        ...devices['iPad Pro 11'],
       },
       testMatch: /.*\.(spec|test)\.ts/, // Run all tests
     },
@@ -120,18 +115,14 @@ export default defineConfig({
         deviceScaleFactor: 2,
         isMobile: true,
         hasTouch: true,
+        defaultBrowserType: 'webkit',
       },
       testMatch: /device-responsive\.spec\.ts/,
     },
     {
       name: 'iPad Pro 11 Landscape',
       use: {
-        viewport: { width: 1194, height: 834 },
-        userAgent:
-          'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
-        deviceScaleFactor: 2,
-        isMobile: true,
-        hasTouch: true,
+        ...devices['iPad Pro 11 landscape'],
       },
       testMatch: /.*\.(spec|test)\.ts/, // Run all tests
     },


### PR DESCRIPTION
This change fixes the CI failure where iPad E2E tests were failing due to browser executable mismatches or incorrect browser engine selection.

- **`playwright.config.ts`**:
    - Replaced manual config for "iPad Pro 11 Portrait" and "iPad Pro 11 Landscape" with standard `...devices` descriptors, which correctly set `defaultBrowserType: 'webkit'`.
    - Added `defaultBrowserType: 'webkit'` to "iPad Pro 12.9 Portrait" manual config to ensure it runs on WebKit.
- **`.github/workflows/ci.yml`**:
    - Updated the browser installation logic to install `webkit` when the matrix project name contains "iPad".

This ensures that iPad tests run on the correct browser engine (WebKit) and the CI environment provides that engine.

---
*PR created automatically by Jules for task [9421567770938560309](https://jules.google.com/task/9421567770938560309) started by @jbdevprimary*