### PR TITLE
fix(ci): use webkit for iPad E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
         deviceScaleFactor: 2,
         isMobile: true,
         hasTouch: true,
+        defaultBrowserType: 'webkit',
       },
       testMatch: /.*\.(spec|test)\.ts/, // Run all tests
     },
@@ -120,6 +121,7 @@ export default defineConfig({
         deviceScaleFactor: 2,
         isMobile: true,
         hasTouch: true,
+        defaultBrowserType: 'webkit',
       },
       testMatch: /device-responsive\.spec\.ts/,
     },
@@ -132,6 +134,7 @@ export default defineConfig({
         deviceScaleFactor: 2,
         isMobile: true,
         hasTouch: true,
+        defaultBrowserType: 'webkit',
       },
       testMatch: /.*\.(spec|test)\.ts/, // Run all tests
     },


### PR DESCRIPTION
Fixes CI failure by enforcing WebKit for iPad E2E tests in both Playwright config and CI workflow.

---
*PR created automatically by Jules for task [13157764120911734569](https://jules.google.com/task/13157764120911734569) started by @jbdevprimary*