### PR TITLE
fix(ci): configure iPad E2E tests to use WebKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium

--- a/e2e/governor.spec.ts
+++ b/e2e/governor.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { navigateToGame, screenshot, verifyGamePlaying, verifyHUDVisible } from './helpers/game-helpers';
 import { GameGovernor } from './helpers/game-governor';
+import { navigateToGame, screenshot, verifyGamePlaying } from './helpers/game-helpers';
 
 test.describe('Automated Playthrough with Governor', () => {
   test.setTimeout(90000);

--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -100,11 +100,7 @@ export function getDeviceName(testInfo: TestInfo): string {
 }
 
 /** Take a screenshot with a standardized name: {prefix}-{stage}.png */
-export async function screenshot(
-  page: Page,
-  prefix: string,
-  stage: string
-): Promise<void> {
+export async function screenshot(page: Page, prefix: string, stage: string): Promise<void> {
   await page.screenshot({
     path: `test-results/screenshots/${prefix}-${stage}.png`,
     fullPage: false,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 11 Portrait',
       use: {
+        browserName: 'webkit',
         viewport: { width: 834, height: 1194 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
@@ -114,6 +115,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 12.9 Portrait',
       use: {
+        browserName: 'webkit',
         viewport: { width: 1024, height: 1366 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
@@ -126,6 +128,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 11 Landscape',
       use: {
+        browserName: 'webkit',
         viewport: { width: 1194, height: 834 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',


### PR DESCRIPTION
This PR fixes the CI failure where iPad E2E tests were failing or misconfigured. It ensures that iPad tests run on WebKit (simulating iOS) as required, and updates the CI workflow to install the correct browser. It also fixes some linting issues found during local verification.

---
*PR created automatically by Jules for task [4990684904861472098](https://jules.google.com/task/4990684904861472098) started by @jbdevprimary*