### PR TITLE
fix(ci): fix iPad E2E tests by setting correct browser type

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         deviceScaleFactor: 2,
         isMobile: true,
         hasTouch: true,
+        defaultBrowserType: 'webkit',
       },
       testMatch: /.*\.(spec|test)\.ts/, // Run all tests
     },
@@ -122,6 +123,7 @@ export default defineConfig({
         deviceScaleFactor: 2,
         isMobile: true,
         hasTouch: true,
+        defaultBrowserType: 'webkit',
       },
       testMatch: /device-responsive\.spec\.ts/,
     },
@@ -135,6 +137,7 @@ export default defineConfig({
         deviceScaleFactor: 2,
         isMobile: true,
         hasTouch: true,
+        defaultBrowserType: 'webkit',
       },
       testMatch: /.*\.(spec|test)\.ts/, // Run all tests
     },


### PR DESCRIPTION
Fixes iPad E2E test failures by explicitly setting `defaultBrowserType: 'webkit'` in `playwright.config.ts` for all iPad projects. This ensures that Playwright attempts to launch WebKit (which is installed by the CI workflow) instead of defaulting to Chromium (which is not installed for these jobs).

---
*PR created automatically by Jules for task [13102510607525647022](https://jules.google.com/task/13102510607525647022) started by @jbdevprimary*