### PR TITLE
fix(ci): resolve E2E configuration and helper issues

### DIFF
--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -87,13 +87,14 @@ export async function getCanvasBoundingBox(
   let resultBox: { x: number; y: number; width: number; height: number } | null = null;
   await expect(async () => {
     const box = await canvas.boundingBox();
-    expect(box).toBeTruthy();
-    expect(box!.width).toBeGreaterThan(0);
-    expect(box!.height).toBeGreaterThan(0);
+    if (!box) throw new Error('Canvas bounding box is null');
+    expect(box.width).toBeGreaterThan(0);
+    expect(box.height).toBeGreaterThan(0);
     resultBox = box;
   }).toPass({ timeout: 10000 });
 
-  return resultBox!;
+  if (!resultBox) throw new Error('Failed to get canvas bounding box');
+  return resultBox;
 }
 
 // ─── Screenshots ─────────────────────────────────────────────

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 11 Portrait',
       use: {
+        browserName: 'webkit',
         viewport: { width: 834, height: 1194 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
@@ -114,6 +115,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 12.9 Portrait',
       use: {
+        browserName: 'webkit',
         viewport: { width: 1024, height: 1366 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
@@ -126,6 +128,7 @@ export default defineConfig({
     {
       name: 'iPad Pro 11 Landscape',
       use: {
+        browserName: 'webkit',
         viewport: { width: 1194, height: 834 },
         userAgent:
           'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',


### PR DESCRIPTION
- Fix E2E test failures on iPad by explicitly setting `browserName: 'webkit'` in `playwright.config.ts`, aligning with the CI workflow which installs WebKit for iPad projects.
- Fix lint errors in `e2e/helpers/game-helpers.ts` by replacing non-null assertions (`!`) with runtime guards (`if (!box) throw ...`) for bounding box checks.
- Verified with `pnpm lint` and `pnpm typecheck`.

---
*PR created automatically by Jules for task [16756979981430152813](https://jules.google.com/task/16756979981430152813) started by @jbdevprimary*