### PR TITLE
fix(ci): restore webkit installation for iPad E2E matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
Reverts the incorrect change in #41 that removed iPad from the WebKit installation condition. iPad projects in `playwright.config.ts` explicitly use `browserName: 'webkit'`, so they require the WebKit browser to be installed in CI. This fixes the 'Executable doesn't exist' error in E2E matrix jobs.

---
*PR created automatically by Jules for task [5352591294825542313](https://jules.google.com/task/5352591294825542313) started by @jbdevprimary*