### PR TITLE
fix(ci): restore webkit installation for iPad E2E matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
Restores `webkit` installation for iPad E2E matrix jobs in `.github/workflows/ci.yml`. This fixes the "Executable doesn't exist" error in CI, aligning the environment with the `playwright.config.ts` configuration which explicitly requests `webkit` for iPad projects.

---
*PR created automatically by Jules for task [14594477091989396762](https://jules.google.com/task/14594477091989396762) started by @jbdevprimary*