### PR TITLE
fix(ci): restore webkit installation for iPad E2E matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
Restores "iPad" to the WebKit installation condition in `.github/workflows/ci.yml`.
This ensures that the correct browser executable is available for iPad E2E tests, which are configured to use WebKit.

---
*PR created automatically by Jules for task [1805216825111039498](https://jules.google.com/task/1805216825111039498) started by @jbdevprimary*