### PR TITLE
fix(ci): restore webkit installation for iPad matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ "${{ matrix.project }}" == *"Firefox"* ]]; then
             pnpm exec playwright install --with-deps firefox
-          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* ]]; then
+          elif [[ "${{ matrix.project }}" == *"Safari"* || "${{ matrix.project }}" == *"iPhone"* || "${{ matrix.project }}" == *"iPad"* ]]; then
             pnpm exec playwright install --with-deps webkit
           else
             pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
Restored `iPad` to the condition in `.github/workflows/ci.yml` that triggers WebKit installation.
Verified that `playwright.config.ts` requires WebKit for iPad projects.
Ran lint, typecheck, and unit tests to ensure no regressions.

---
*PR created automatically by Jules for task [16312456705203704152](https://jules.google.com/task/16312456705203704152) started by @jbdevprimary*