### PR TITLE
fix(ci): update biome.json schema to match v2.4.0

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
Updated `biome.json` schema URL from `2.3.15` to `2.4.0` to match the installed version of `@biomejs/biome` updated by Dependabot. This resolves the lint warning "The configuration schema version does not match the CLI version" which was causing CI to fail. Verified locally that `pnpm lint` passes cleanly.

---
*PR created automatically by Jules for task [9900575609608402649](https://jules.google.com/task/9900575609608402649) started by @jbdevprimary*