### PR TITLE
fix(ci): resolve lint and typecheck failures

### DIFF
--- a/e2e/governor.spec.ts
+++ b/e2e/governor.spec.ts
@@ -106,7 +106,6 @@ test.describe('Automated Playthrough with Governor', () => {
     // Wait for worker to initialize and send first state update
     // The time display should change from initial 0 to the wave duration (e.g., 28)
     const timeDisplay = page.locator('#time-display');
-    await expect(async () => {
     await verifyGamePlaying(page);
 
     // Let governor play

--- a/src/lib/ai/director.ts
+++ b/src/lib/ai/director.ts
@@ -255,7 +255,7 @@ class RelievingState extends State<AIDirector> {
 
   override execute(director: AIDirector): void {
     // Slowly reduce tension further
-    director.targetTension = Math.max(0.1, director.targetTension - 0.01 * director.frameDelta);
+    director.targetTension = Math.max(0.1, director.targetTension - 0.01 * director.lastDelta);
     // Once panic drops and player stabilizes, start building again
     if (
       director.performance.panic < 50 &&


### PR DESCRIPTION
This PR fixes the CI failures that were blocking the build. 

Changes:
1.  **e2e/governor.spec.ts**: Removed an erroneous `await expect(async () => {` line that was causing a parsing error due to an unclosed brace. This likely resulted from a previous merge or refactor.
2.  **src/lib/ai/director.ts**: Replaced `director.frameDelta` with `director.lastDelta` in the `RelievingState` execution logic. `frameDelta` is not a property of the `AIDirector` class, causing a TypeScript error. `lastDelta` is the correct property holding the time delta.

Verification:
- `pnpm lint`: Passed
- `pnpm exec tsc --noEmit`: Passed
- `pnpm test`: Passed
- `pnpm build`: Passed

---
*PR created automatically by Jules for task [6274885640225063027](https://jules.google.com/task/6274885640225063027) started by @jbdevprimary*