### PR TITLE
fix(ci): resolve syntax error in e2e test and type error in ai director

### DIFF
--- a/e2e/governor.spec.ts
+++ b/e2e/governor.spec.ts
@@ -107,7 +107,8 @@ test.describe('Automated Playthrough with Governor', () => {
     // The time display should change from initial 0 to the wave duration (e.g., 28)
     const timeDisplay = page.locator('#time-display');
     await expect(async () => {
-    await verifyGamePlaying(page);
+      await verifyGamePlaying(page);
+    }).toPass();
 
     // Let governor play
     governor.start().catch((err) => console.error('Governor start failed:', err));

--- a/src/lib/ai/director.ts
+++ b/src/lib/ai/director.ts
@@ -255,7 +255,7 @@ class RelievingState extends State<AIDirector> {
 
   override execute(director: AIDirector): void {
     // Slowly reduce tension further
-    director.targetTension = Math.max(0.1, director.targetTension - 0.01 * director.frameDelta);
+    director.targetTension = Math.max(0.1, director.targetTension - 0.01 * director.lastDelta);
     // Once panic drops and player stabilizes, start building again
     if (
       director.performance.panic < 50 &&


### PR DESCRIPTION
Fixes a syntax error in `e2e/governor.spec.ts` where an `expect` block was unclosed, causing lint failures. Also fixes a type error in `src/lib/ai/director.ts` where `frameDelta` was used instead of `lastDelta`. Verified locally with lint, typecheck, and unit tests.

---
*PR created automatically by Jules for task [18260900571098214439](https://jules.google.com/task/18260900571098214439) started by @jbdevprimary*