### PR TITLE
fix(ci): increase workflow wait timeout to 60m

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: CI Success
           ref: ${{ github.event.pull_request.head.sha }}
-          timeoutSeconds: 1800
+          timeoutSeconds: 3600
           intervalSeconds: 30
 
       - name: Check CI result

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: CI Success
           ref: ${{ github.sha }}
-          timeoutSeconds: 1800
+          timeoutSeconds: 3600
           intervalSeconds: 30
 
       - name: Check CI result


### PR DESCRIPTION
The CD workflow was failing with a timeout error because it was configured to wait only 30 minutes for the CI workflow to complete. With the recent addition of a comprehensive E2E test matrix (20 parallel jobs), the CI workflow duration frequently exceeds 30 minutes.

This change:
- Increases `timeoutSeconds` in `.github/workflows/cd.yml` to 3600 (60 minutes).
- Increases `timeoutSeconds` in `.github/workflows/automerge.yml` to 3600 (60 minutes) to match.

This ensures that downstream workflows wait long enough for the full validation suite to finish.

---
*PR created automatically by Jules for task [3035401311723572570](https://jules.google.com/task/3035401311723572570) started by @jbdevprimary*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended CI/CD pipeline timeout duration from 30 to 60 minutes, reducing the likelihood of deployment failures due to processing delays and improving overall build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->