### PR TITLE
fix(e2e): resolve governor spec syntax error and timeout

### DIFF
--- a/e2e/governor.spec.ts
+++ b/e2e/governor.spec.ts
@@ -3,7 +3,7 @@ import { GameGovernor } from './helpers/game-governor';
 import { navigateToGame, screenshot, verifyGamePlaying } from './helpers/game-helpers';
 
 test.describe('Automated Playthrough with Governor', () => {
-  test.setTimeout(90000);
+  test.setTimeout(120000);
 
   test('should run automated playthrough with default settings', async ({ page }) => {
     await navigateToGame(page);
@@ -106,7 +106,6 @@ test.describe('Automated Playthrough with Governor', () => {
     // Wait for worker to initialize and send first state update
     // The time display should change from initial 0 to the wave duration (e.g., 28)
     const timeDisplay = page.locator('#time-display');
-    await expect(async () => {
     await verifyGamePlaying(page);
 
     // Let governor play


### PR DESCRIPTION
Resolves a CI failure caused by a syntax error (stray 'await expect') in e2e/governor.spec.ts. Also increases the test timeout to 120s to prevent flakiness in slower CI environments.

---
*PR created automatically by Jules for task [5962035811763048012](https://jules.google.com/task/5962035811763048012) started by @jbdevprimary*