### PR TITLE
Fix Vite worker chunk loading and E2E stability

### DIFF
--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -10,8 +10,8 @@ import { expect } from '@playwright/test';
 
 // ─── Timeouts ────────────────────────────────────────────────
 
-export const GAME_START_TIMEOUT = 3000;
-export const WAVE_ANNOUNCE_TIMEOUT = 5000;
+export const GAME_START_TIMEOUT = 10000;
+export const WAVE_ANNOUNCE_TIMEOUT = 10000;
 export const GAMEPLAY_TIMEOUT = 60000;
 
 // ─── Navigation ──────────────────────────────────────────────
@@ -59,10 +59,10 @@ export async function verifyHUDVisible(page: Page): Promise<void> {
 
 /** Verify control buttons exist in the DOM (hidden for a11y/e2e, 3D keyboard is primary) */
 export async function verifyControlsAttached(page: Page): Promise<void> {
-  await expect(page.locator('#btn-reality')).toBeAttached();
-  await expect(page.locator('#btn-history')).toBeAttached();
-  await expect(page.locator('#btn-logic')).toBeAttached();
-  await expect(page.locator('#btn-special')).toBeAttached();
+  await expect(page.getByTestId('btn-reality')).toBeAttached();
+  await expect(page.getByTestId('btn-history')).toBeAttached();
+  await expect(page.getByTestId('btn-logic')).toBeAttached();
+  await expect(page.getByTestId('btn-special')).toBeAttached();
 }
 
 /** Verify powerup indicators are visible */

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -388,16 +388,31 @@ export default function Game() {
           {/* Controls are now 3D keyboard F-keys in the scene.
               Hidden HTML buttons kept for accessibility and e2e test IDs. */}
           <div id="controls" className="sr-only">
-            <button type="button" id="btn-reality" onClick={() => handleAbility('reality')}>
+            <button
+              type="button"
+              id="btn-reality"
+              data-testid="btn-reality"
+              onClick={() => handleAbility('reality')}
+            >
               REALITY
             </button>
-            <button type="button" id="btn-history" onClick={() => handleAbility('history')}>
+            <button
+              type="button"
+              id="btn-history"
+              data-testid="btn-history"
+              onClick={() => handleAbility('history')}
+            >
               HISTORY
             </button>
-            <button type="button" id="btn-logic" onClick={() => handleAbility('logic')}>
+            <button
+              type="button"
+              id="btn-logic"
+              data-testid="btn-logic"
+              onClick={() => handleAbility('logic')}
+            >
               LOGIC
             </button>
-            <button type="button" id="btn-special" onClick={handleNuke}>
+            <button type="button" id="btn-special" data-testid="btn-special" onClick={handleNuke}>
               NUKE
             </button>
           </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,13 +36,7 @@ export default defineConfig({
             '@capacitor/status-bar',
           ],
 
-          // Game logic chunks
-          'game-logic': [
-            './src/lib/game-logic.ts',
-            './src/lib/constants.ts',
-            './src/lib/events.ts',
-          ],
-          'game-ecs': ['./src/ecs/world.ts', './src/ecs/react.ts', './src/ecs/state-sync.ts'],
+          // Game utils chunk
           'game-utils': [
             './src/lib/audio.ts',
             './src/lib/storage.ts',


### PR DESCRIPTION
Resolved CI/CD workflow failure by fixing a Vite build configuration issue that prevented the Web Worker from loading dependencies correctly. Removed `game-logic` and `game-ecs` from `manualChunks` in `vite.config.ts` to ensure proper bundling for the worker (which uses `iife` format).

Also improved E2E test stability by:
- Adding `data-testid` attributes to control buttons in `src/components/Game.tsx`.
- Updating `e2e/helpers/game-helpers.ts` to use robust `getByTestId` selectors instead of IDs.
- Increasing `GAME_START_TIMEOUT` and `WAVE_ANNOUNCE_TIMEOUT` to 10000ms to accommodate slower CI environments and worker initialization latency.

These changes fix the `device-responsive` and `playthrough` failures observed in the CI workflow.

---
*PR created automatically by Jules for task [1979911640663441451](https://jules.google.com/task/1979911640663441451) started by @jbdevprimary*