### PR TITLE
fix(e2e): robustify playthrough test with timeouts and early checks

### DIFF
--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -11,7 +11,7 @@ import { expect } from '@playwright/test';
 // ─── Timeouts ────────────────────────────────────────────────
 
 export const GAME_START_TIMEOUT = 3000;
-export const WAVE_ANNOUNCE_TIMEOUT = 5000;
+export const WAVE_ANNOUNCE_TIMEOUT = 10000;
 export const GAMEPLAY_TIMEOUT = 60000;
 
 // ─── Navigation ──────────────────────────────────────────────

--- a/e2e/playthrough.spec.ts
+++ b/e2e/playthrough.spec.ts
@@ -8,6 +8,7 @@ import {
   verifyGamePlaying,
   verifyHUDVisible,
   verifyPowerupsVisible,
+  WAVE_ANNOUNCE_TIMEOUT,
 } from './helpers/game-helpers';
 
 /**
@@ -21,6 +22,8 @@ import {
  * The device-responsive.spec.ts handles cross-device validation.
  */
 test.describe('Complete Game Playthrough', () => {
+  test.setTimeout(90000);
+
   test('should complete a full game playthrough from start to wave 1', async ({ page }) => {
     await navigateToGame(page);
     await screenshot(page, 'playthrough', '01-start-screen');
@@ -34,15 +37,18 @@ test.describe('Complete Game Playthrough', () => {
 
     // ── Start game via spacebar ───────────────────────
     await startGame(page);
+
+    // ── Wave announcement ─────────────────────────────
+    // Verify wave announcement appears immediately (avoid race condition with screenshot)
+    await expect(page.locator('#wave-announce')).toHaveClass(/show/, { timeout: WAVE_ANNOUNCE_TIMEOUT });
+
     await screenshot(page, 'playthrough', '02-game-started');
 
     // Verify transition: overlay hidden, UI visible
     await verifyGamePlaying(page);
     await expect(page.locator('#ui-layer')).not.toHaveClass(/hidden/);
 
-    // ── Wave announcement ─────────────────────────────
     await expect(page.locator('#wave-display')).toContainText('WAVE 1');
-    await expect(page.locator('#wave-announce')).toHaveClass(/show/, { timeout: 5000 });
     await screenshot(page, 'playthrough', '03-wave-announcement');
 
     // ── HUD elements ──────────────────────────────────


### PR DESCRIPTION
Resolved E2E smoke test failures in `playthrough.spec.ts` caused by timing issues in CI environments.

The test failure `expect(locator).toHaveClass(/show/)` was caused by a combination of two factors:
1. The wave announcement is transient (visible for ~3s).
2. The test was performing a screenshot (which can be slow) *before* verifying the announcement, causing it to miss the window of visibility.
3. The overall test execution was exceeding the default timeout.

This fix:
- Moves the verification of `#wave-announce` to happen immediately after `startGame`, ensuring we catch the `show` class before it disappears.
- Increases the wait timeout for the announcement to 10s (from 5s).
- Increases the overall test timeout for `playthrough.spec.ts` to 90s (consistent with `governor.spec.ts`).

Verified with local `xvfb-run pnpm exec playwright test`.

---
*PR created automatically by Jules for task [2229981823111519584](https://jules.google.com/task/2229981823111519584) started by @jbdevprimary*