### PR TITLE
fix(test): resolve type mismatch in boss-ai.test.ts

### DIFF
--- a/src/lib/ai/boss-ai.test.ts
+++ b/src/lib/ai/boss-ai.test.ts
@@ -3,7 +3,7 @@ import type { EnemyType } from '../types';
 import { BossAI, type BossState } from './boss-ai';
 
 const mockEnemyType: EnemyType = {
-  name: 'test',
+  icon: 'test-icon',
   color: '#fff',
   words: ['test'],
   counter: 'reality',


### PR DESCRIPTION
Resolved a TypeScript compilation error in `src/lib/ai/boss-ai.test.ts` where `mockEnemyType` did not conform to the `EnemyType` interface. The `name` property was removed and the missing `icon` property was added, ensuring `pnpm typecheck` and the CI build pass. Verified locally with `pnpm exec tsc --noEmit` and `pnpm test`.

---
*PR created automatically by Jules for task [991688451849633211](https://jules.google.com/task/991688451849633211) started by @jbdevprimary*