### PR TITLE
fix(e2e): robust assertions for canvas and increased timeouts

### DIFF
--- a/e2e/game.spec.ts
+++ b/e2e/game.spec.ts
@@ -32,16 +32,17 @@ test.describe('Psyduck Panic Game', () => {
     await expect(container).toBeVisible();
 
     // R3F wraps the actual canvas inside a container div
-    const box = await container.boundingBox();
-    expect(box).not.toBeNull();
-    if (box) {
+    // Use polling to handle potential layout shifts/hydration
+    await expect(async () => {
+      const box = await container.boundingBox();
+      if (!box) throw new Error('Canvas container bounding box is null');
       expect(box.width).toBeGreaterThanOrEqual(100);
       expect(box.height).toBeGreaterThanOrEqual(75);
-    }
+    }).toPass({ timeout: 10000 });
 
     // Verify an actual WebGL canvas exists inside the R3F container
-    const canvasCount = await container.locator('canvas').count();
-    expect(canvasCount).toBeGreaterThanOrEqual(1);
+    // Use retrying assertion for robust check
+    await expect(container.locator('canvas')).toHaveCount(1, { timeout: 10000 });
   });
 
   test('should have control buttons', async ({ page }) => {

--- a/e2e/playthrough.spec.ts
+++ b/e2e/playthrough.spec.ts
@@ -43,7 +43,7 @@ test.describe('Complete Game Playthrough', () => {
 
     // ── Wave announcement ─────────────────────────────
     // Check transient UI immediately before blocking operations like screenshot
-    await expect(page.locator('#wave-announce')).toHaveClass(/show/, { timeout: 10000 });
+    await expect(page.locator('#wave-announce')).toHaveClass(/show/, { timeout: 20000 });
     await expect(page.locator('#wave-display')).toContainText('WAVE 1');
 
     await screenshot(page, 'playthrough', '02-game-started');


### PR DESCRIPTION
Resolve flaky E2E smoke test failures in CI caused by canvas hydration timing and slow wave announcements.
- Use polling assertions (`toPass`) for canvas dimensions in `e2e/game.spec.ts`.
- Use retrying assertion (`toHaveCount`) for canvas element existence.
- Increase wave announcement timeout to 20s in `e2e/playthrough.spec.ts`.

---
*PR created automatically by Jules for task [14723417081580749067](https://jules.google.com/task/14723417081580749067) started by @jbdevprimary*