### PR TITLE
fix(ci): update Playwright Docker image to v1.58.2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
     name: E2E Matrix - ${{ matrix.project }}
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     needs: [deploy-web]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
     name: E2E Smoke Tests
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     needs: [security]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Update Playwright Docker image in CI/CD workflows to match the installed package version (v1.58.2), resolving "Executable doesn't exist" errors.

---
*PR created automatically by Jules for task [9611789075222673439](https://jules.google.com/task/9611789075222673439) started by @jbdevprimary*