### PR TITLE
Fix E2E flakiness in governor and playthrough tests

### DIFF
--- a/e2e/governor.spec.ts
+++ b/e2e/governor.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { GameGovernor } from './helpers/game-governor';
-import { navigateToGame, screenshot, startGame, verifyGamePlaying } from './helpers/game-helpers';
+import {
+  deviceScreenshot,
+  navigateToGame,
+  startGame,
+  verifyGamePlaying,
+} from './helpers/game-helpers';
 
 /**
  * AI Governor-driven playthrough.
@@ -9,20 +14,21 @@ import { navigateToGame, screenshot, startGame, verifyGamePlaying } from './help
  * Full matrix (CD): runs all variants (aggressive, defensive, verify-running).
  */
 test.describe('Automated Playthrough with Governor', () => {
-  test.setTimeout(90000);
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(180000);
 
   test('should run automated playthrough with default settings', async ({ page }) => {
     await navigateToGame(page);
-    await screenshot(page, 'governor', '01-start');
+    await deviceScreenshot(page, test.info(), 'governor-01-start');
 
     const governor = new GameGovernor(page);
     const playthroughPromise = governor.playthrough();
 
     await page.waitForTimeout(5000);
-    await screenshot(page, 'governor', '02-gameplay');
+    await deviceScreenshot(page, test.info(), 'governor-02-gameplay');
 
     await page.waitForTimeout(5000);
-    await screenshot(page, 'governor', '03-mid-game');
+    await deviceScreenshot(page, test.info(), 'governor-03-mid-game');
 
     const result = await Promise.race([
       playthroughPromise,
@@ -34,7 +40,7 @@ test.describe('Automated Playthrough with Governor', () => {
       ),
     ]);
 
-    await screenshot(page, 'governor', '04-end');
+    await deviceScreenshot(page, test.info(), 'governor-04-end');
     expect(result).toBeTruthy();
     expect(result.score).toBeGreaterThanOrEqual(0);
     console.log(`Playthrough completed with result: ${result.result}, score: ${result.score}`);
@@ -54,7 +60,7 @@ test.describe('Automated Playthrough with Governor', () => {
     const playthroughPromise = governor.playthrough();
 
     await page.waitForTimeout(5000);
-    await screenshot(page, 'governor-aggressive', '01-gameplay');
+    await deviceScreenshot(page, test.info(), 'governor-aggressive-01-gameplay');
 
     const result = await Promise.race([
       playthroughPromise,
@@ -66,7 +72,7 @@ test.describe('Automated Playthrough with Governor', () => {
       ),
     ]);
 
-    await screenshot(page, 'governor-aggressive', '02-end');
+    await deviceScreenshot(page, test.info(), 'governor-aggressive-02-end');
     expect(result).toBeTruthy();
     console.log(`Aggressive playthrough: ${result.result}, score: ${result.score}`);
   });
@@ -84,7 +90,7 @@ test.describe('Automated Playthrough with Governor', () => {
     const playthroughPromise = governor.playthrough();
 
     await page.waitForTimeout(5000);
-    await screenshot(page, 'governor-defensive', '01-gameplay');
+    await deviceScreenshot(page, test.info(), 'governor-defensive-01-gameplay');
 
     const result = await Promise.race([
       playthroughPromise,
@@ -96,7 +102,7 @@ test.describe('Automated Playthrough with Governor', () => {
       ),
     ]);
 
-    await screenshot(page, 'governor-defensive', '02-end');
+    await deviceScreenshot(page, test.info(), 'governor-defensive-02-end');
     expect(result).toBeTruthy();
     console.log(`Defensive playthrough: ${result.result}, score: ${result.score}`);
   });
@@ -135,6 +141,6 @@ test.describe('Automated Playthrough with Governor', () => {
     }
 
     governor.stop();
-    await screenshot(page, 'governor', 'verify-running');
+    await deviceScreenshot(page, test.info(), 'governor-verify-running');
   });
 });

--- a/e2e/helpers/game-governor.ts
+++ b/e2e/helpers/game-governor.ts
@@ -39,16 +39,23 @@ export class GameGovernor {
   async start(): Promise<void> {
     this.isRunning = true;
 
-    // Use keyboard instead of click because an unhandled font-fetch
-    // rejection from troika-three-text (offline CI) breaks React 18's
-    // synthetic event dispatch for mouse/pointer events while native
-    // keyboard listeners remain unaffected.
-    const startBtn = this.page.locator('#start-btn');
-    await expect(startBtn).toBeVisible();
-    await this.page.keyboard.press(' ');
+    // Check if game is already running (overlay hidden)
+    const overlay = this.page.locator('#overlay');
+    const isHidden = await overlay.evaluate((el) => el.classList.contains('hidden'));
 
-    // Wait for game to start
-    await this.page.waitForTimeout(1000);
+    if (!isHidden) {
+      // Game not running, start it
+      // Use keyboard instead of click because an unhandled font-fetch
+      // rejection from troika-three-text (offline CI) breaks React 18's
+      // synthetic event dispatch for mouse/pointer events while native
+      // keyboard listeners remain unaffected.
+      const startBtn = this.page.locator('#start-btn');
+      await expect(startBtn).toBeVisible();
+      await this.page.keyboard.press(' ');
+
+      // Wait for game to start
+      await this.page.waitForTimeout(1000);
+    }
 
     // Start gameplay loop
     await this.playLoop();

--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -10,10 +10,10 @@ import { expect } from '@playwright/test';
 
 // ─── Timeouts ────────────────────────────────────────────────
 
-export const GAME_START_TIMEOUT = 3000;
-export const WAVE_ANNOUNCE_TIMEOUT = 5000;
+export const GAME_START_TIMEOUT = 10000;
+export const WAVE_ANNOUNCE_TIMEOUT = 15000;
 export const GAMEPLAY_TIMEOUT = 60000;
-export const E2E_PLAYTHROUGH_TIMEOUT = 90000;
+export const E2E_PLAYTHROUGH_TIMEOUT = 180000;
 
 // ─── Navigation ──────────────────────────────────────────────
 
@@ -51,32 +51,40 @@ export async function startGameWithSpacebar(page: Page): Promise<void> {
 
 /** Verify all HUD elements are visible during gameplay */
 export async function verifyHUDVisible(page: Page): Promise<void> {
-  await expect(page.locator('#wave-display')).toBeVisible();
-  await expect(page.locator('#time-display')).toBeVisible();
-  await expect(page.locator('#score-display')).toBeVisible();
-  await expect(page.locator('#panic-bar')).toBeVisible();
-  await expect(page.locator('#combo-display')).toBeVisible();
+  await Promise.all([
+    expect(page.locator('#wave-display')).toBeVisible(),
+    expect(page.locator('#time-display')).toBeVisible(),
+    expect(page.locator('#score-display')).toBeVisible(),
+    expect(page.locator('#panic-bar')).toBeVisible(),
+    expect(page.locator('#combo-display')).toBeVisible(),
+  ]);
 }
 
 /** Verify control buttons exist in the DOM (hidden for a11y/e2e, 3D keyboard is primary) */
 export async function verifyControlsAttached(page: Page): Promise<void> {
-  await expect(page.locator('#btn-reality')).toBeAttached();
-  await expect(page.locator('#btn-history')).toBeAttached();
-  await expect(page.locator('#btn-logic')).toBeAttached();
-  await expect(page.locator('#btn-special')).toBeAttached();
+  await Promise.all([
+    expect(page.locator('#btn-reality')).toBeAttached(),
+    expect(page.locator('#btn-history')).toBeAttached(),
+    expect(page.locator('#btn-logic')).toBeAttached(),
+    expect(page.locator('#btn-special')).toBeAttached(),
+  ]);
 }
 
 /** Verify powerup indicators are visible */
 export async function verifyPowerupsVisible(page: Page): Promise<void> {
-  await expect(page.locator('#pu-slow')).toBeVisible();
-  await expect(page.locator('#pu-shield')).toBeVisible();
-  await expect(page.locator('#pu-double')).toBeVisible();
+  await Promise.all([
+    expect(page.locator('#pu-slow')).toBeVisible(),
+    expect(page.locator('#pu-shield')).toBeVisible(),
+    expect(page.locator('#pu-double')).toBeVisible(),
+  ]);
 }
 
 /** Verify the game is currently playing (overlay hidden, HUD visible) */
 export async function verifyGamePlaying(page: Page): Promise<void> {
-  await expect(page.locator('#overlay')).toHaveClass(/hidden/);
-  await expect(page.locator('#ui-layer')).not.toHaveClass(/hidden/);
+  await Promise.all([
+    expect(page.locator('#overlay')).toHaveClass(/hidden/),
+    expect(page.locator('#ui-layer')).not.toHaveClass(/hidden/),
+  ]);
 }
 
 // ─── Canvas ──────────────────────────────────────────────────


### PR DESCRIPTION
Resolved CI failures in E2E tests caused by timeouts, race conditions, and resource contention.
    
    Changes:
    - `e2e/helpers/game-governor.ts`: robust start logic.
    - `e2e/helpers/game-helpers.ts`: increased timeouts, parallel verification.
    - `e2e/governor.spec.ts`: serial mode, increased timeout, unique screenshots.
    - `e2e/playthrough.spec.ts`: serial mode, unique screenshots, optimized checks, robust end verification.

---
*PR created automatically by Jules for task [15845150811243229650](https://jules.google.com/task/15845150811243229650) started by @jbdevprimary*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test execution timeouts for enhanced validation
  * Updated screenshot capture mechanisms and verification methods
  * Modified test execution configuration for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->