### PR TITLE
fix(e2e): resolve race condition in game start and increase timeouts

### DIFF
--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -10,7 +10,7 @@ import { expect } from '@playwright/test';
 
 // ─── Timeouts ────────────────────────────────────────────────
 
-export const GAME_START_TIMEOUT = 3000;
+export const GAME_START_TIMEOUT = 10000;
 export const WAVE_ANNOUNCE_TIMEOUT = 5000;
 export const GAMEPLAY_TIMEOUT = 60000;
 export const E2E_PLAYTHROUGH_TIMEOUT = 90000;


### PR DESCRIPTION
- Decouple keyboard input handling from worker initialization in Game.tsx to ensure inputs are captured immediately.
- Add retry logic for sending the START message to the worker to handle slow initialization.
- Increase GAME_START_TIMEOUT in e2e/helpers/game-helpers.ts to 10s.
- Remove .ci-failure-artifacts/ directory.

---
*PR created automatically by Jules for task [2755678957673412139](https://jules.google.com/task/2755678957673412139) started by @jbdevprimary*