### PR TITLE
fix(ci): resolve biome linting and formatting issues

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -484,7 +484,9 @@ export default function Game() {
               </div>
               <div className="stat-row">
                 <span className="stat-label">WAVES CLEARED</span>
-                <span className="stat-value">{ui.gameOverStats.wavesCleared} / {WAVES.length}</span>
+                <span className="stat-value">
+                  {ui.gameOverStats.wavesCleared} / {WAVES.length}
+                </span>
               </div>
               <div className="stat-row">
                 <span className="stat-label">MAX COMBO</span>

--- a/src/components/scene/systems/EnemySystem.tsx
+++ b/src/components/scene/systems/EnemySystem.tsx
@@ -112,7 +112,6 @@ function EnemyMesh({ entity }: { entity: (typeof enemies.entities)[number] }) {
           gapSize={0.15}
         />
       )}
-
     </group>
   );
 }

--- a/src/lib/game-logic.test.ts
+++ b/src/lib/game-logic.test.ts
@@ -89,7 +89,7 @@ describe('GameLogic', () => {
       game.spawnPowerUp();
       const powerup = game.powerups[0];
 
-      expect(['slow', 'shield', 'double'].some(t => powerup.id.startsWith(t + '-'))).toBe(true);
+      expect(['slow', 'shield', 'double'].some((t) => powerup.id.startsWith(`${t}-`))).toBe(true);
       expect(powerup.x).toBeGreaterThan(0);
       expect(powerup.y).toBeDefined();
     });

--- a/src/lib/music.ts
+++ b/src/lib/music.ts
@@ -171,7 +171,8 @@ export class AdaptiveMusic {
     // Bass gets louder and more aggressive
     if (this.bassSynth) {
       this.bassSynth.volume.value = -8 + (this.panic / 100) * 4;
-      const bassType: 'sawtooth' | 'square' | 'triangle' = this.panic > 66 ? 'sawtooth' : this.panic > 33 ? 'square' : 'triangle';
+      const bassType: 'sawtooth' | 'square' | 'triangle' =
+        this.panic > 66 ? 'sawtooth' : this.panic > 33 ? 'square' : 'triangle';
       if (this.bassSynth.oscillator.type !== bassType) {
         this.bassSynth.oscillator.type = bassType;
       }


### PR DESCRIPTION
This PR resolves linting and formatting issues introduced by the update to `@biomejs/biome` v2.4.0, which caused the CI pipeline to fail.

### Changes
- Applied automated formatting fixes via `pnpm lint:fix` to:
  - `src/components/Game.tsx` (JSX line wrapping)
  - `src/components/scene/systems/EnemySystem.tsx` (Whitespace)
  - `src/lib/music.ts` (Line wrapping)
- Manually fixed a linting error in `src/lib/game-logic.test.ts` where string concatenation was used instead of a template literal (enforced by `lint/style/useTemplate`).

### Verification
- `pnpm lint`: Passed (0 errors)
- `pnpm test`: Passed (158 tests)
- `pnpm build`: Passed
- `pnpm exec tsc --noEmit`: Passed

---
*PR created automatically by Jules for task [16042424970070761771](https://jules.google.com/task/16042424970070761771) started by @jbdevprimary*