### PR TITLE
fix(e2e): increase timeouts and robustness for smoke tests

### DIFF
--- a/e2e/helpers/game-governor.ts
+++ b/e2e/helpers/game-governor.ts
@@ -39,16 +39,20 @@ export class GameGovernor {
   async start(): Promise<void> {
     this.isRunning = true;
 
-    // Use keyboard instead of click because an unhandled font-fetch
-    // rejection from troika-three-text (offline CI) breaks React 18's
-    // synthetic event dispatch for mouse/pointer events while native
-    // keyboard listeners remain unaffected.
-    const startBtn = this.page.locator('#start-btn');
-    await expect(startBtn).toBeVisible();
-    await this.page.keyboard.press(' ');
+    // Check if game is already running (overlay hidden)
+    const overlay = this.page.locator('#overlay');
+    if (await overlay.isVisible()) {
+      // Use keyboard instead of click because an unhandled font-fetch
+      // rejection from troika-three-text (offline CI) breaks React 18's
+      // synthetic event dispatch for mouse/pointer events while native
+      // keyboard listeners remain unaffected.
+      const startBtn = this.page.locator('#start-btn');
+      await expect(startBtn).toBeVisible();
+      await this.page.keyboard.press(' ');
 
-    // Wait for game to start
-    await expect(this.page.locator('#overlay')).toHaveClass(/hidden/, { timeout: 10000 });
+      // Wait for game to start
+      await expect(this.page.locator('#overlay')).toHaveClass(/hidden/, { timeout: 10000 });
+    }
 
     // Start gameplay loop
     await this.playLoop();

--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -11,7 +11,7 @@ import { expect } from '@playwright/test';
 // ─── Timeouts ────────────────────────────────────────────────
 
 export const GAME_START_TIMEOUT = 10000;
-export const WAVE_ANNOUNCE_TIMEOUT = 5000;
+export const WAVE_ANNOUNCE_TIMEOUT = 15000;
 export const GAMEPLAY_TIMEOUT = 60000;
 export const E2E_PLAYTHROUGH_TIMEOUT = 120000;
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,7 +2,7 @@ import type { EnemyType, PowerUp, Wave } from './types';
 
 export const GAME_WIDTH = 800;
 export const GAME_HEIGHT = 600;
-export const WAVE_ANNOUNCEMENT_DURATION = 5000;
+export const WAVE_ANNOUNCEMENT_DURATION = 6000;
 
 export const TYPES: Record<string, EnemyType> = {
   REALITY: {


### PR DESCRIPTION
Increases WAVE_ANNOUNCEMENT_DURATION to 6000ms and WAVE_ANNOUNCE_TIMEOUT to 15000ms to handle CI worker delays. Updates GameGovernor.start() to handle already running games. Removes failure artifacts.

---
*PR created automatically by Jules for task [12865329470719765855](https://jules.google.com/task/12865329470719765855) started by @jbdevprimary*