### PR TITLE
fix(ci): sync Playwright docker image with package version v1.58.2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,7 @@ jobs:
     permissions:
       checks: write
     container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     needs: [deploy-web]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
     name: E2E Smoke Tests
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     needs: [security]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The CI/CD pipeline was failing because the Docker container image (`mcr.microsoft.com/playwright:v1.50.0-noble`) was outdated relative to the project's Playwright dependency (`^1.58.2`). This version mismatch caused `playwright test` to fail when attempting to launch browsers that were not present or compatible in the container.

This change updates the image tag to `v1.58.2-noble` in both `ci.yml` and `cd.yml`, ensuring the CI environment provides the correct browser binaries expected by Playwright v1.58.2.

Verification:
- Confirmed `package.json` specifies `@playwright/test` version `^1.58.2`.
- Confirmed existing workflows used `v1.50.0-noble`.
- Ran local checks (`lint`, `typecheck`, `build`, `test:coverage`) to ensure no regressions.

---
*PR created automatically by Jules for task [15124028152914008519](https://jules.google.com/task/15124028152914008519) started by @jbdevprimary*