### PR TITLE
fix(e2e): robust start logic in smoke tests

### DIFF
--- a/e2e/helpers/game-governor.ts
+++ b/e2e/helpers/game-governor.ts
@@ -6,6 +6,7 @@
  */
 
 import { expect, type Page } from '@playwright/test';
+import { startGame } from './game-helpers';
 
 export interface GovernorConfig {
   /** How aggressively to counter enemies (0-1) */
@@ -42,16 +43,8 @@ export class GameGovernor {
     // Check if game is already running (overlay hidden)
     const overlay = this.page.locator('#overlay');
     if (await overlay.isVisible()) {
-      // Use keyboard instead of click because an unhandled font-fetch
-      // rejection from troika-three-text (offline CI) breaks React 18's
-      // synthetic event dispatch for mouse/pointer events while native
-      // keyboard listeners remain unaffected.
-      const startBtn = this.page.locator('#start-btn');
-      await expect(startBtn).toBeVisible();
-      await this.page.keyboard.press(' ');
-
-      // Wait for game to start
-      await expect(this.page.locator('#overlay')).toHaveClass(/hidden/, { timeout: 10000 });
+      // Use robust helper instead of manual implementation
+      await startGame(this.page);
     }
 
     // Start gameplay loop

--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -32,19 +32,22 @@ export async function navigateToGame(page: Page): Promise<void> {
  *  keyboard listeners remain unaffected. */
 export async function startGame(page: Page): Promise<void> {
   const startBtn = page.locator('#start-btn');
+  const overlay = page.locator('#overlay');
+
   await expect(startBtn).toBeVisible();
-  await page.keyboard.press(' ');
-  await expect(page.locator('#overlay')).toHaveClass(/hidden/, {
-    timeout: GAME_START_TIMEOUT,
-  });
+
+  // Use a retry loop to robustly handle delayed event listener attachment
+  await expect(async () => {
+    if (await overlay.isVisible()) {
+      await page.keyboard.press(' ');
+    }
+    await expect(overlay).toHaveClass(/hidden/);
+  }).toPass({ timeout: GAME_START_TIMEOUT });
 }
 
 /** Start the game by pressing spacebar */
 export async function startGameWithSpacebar(page: Page): Promise<void> {
-  await page.keyboard.press(' ');
-  await expect(page.locator('#overlay')).toHaveClass(/hidden/, {
-    timeout: GAME_START_TIMEOUT,
-  });
+  return startGame(page);
 }
 
 // ─── Verification ────────────────────────────────────────────


### PR DESCRIPTION
- Updated `startGame` helper in `e2e/helpers/game-helpers.ts` to use a retry loop (`expect().toPass()`) for pressing spacebar. This handles race conditions where the event listener is not yet attached.
- Updated `GameGovernor.start()` in `e2e/helpers/game-governor.ts` to use the robust `startGame` helper.
- Removed `.ci-failure-artifacts/` directory.

---
*PR created automatically by Jules for task [11735960196659915924](https://jules.google.com/task/11735960196659915924) started by @jbdevprimary*