### PR TITLE
fix(e2e): robustify start sequence and increase timeouts

### DIFF
--- a/e2e/governor.spec.ts
+++ b/e2e/governor.spec.ts
@@ -9,7 +9,7 @@ import { navigateToGame, screenshot, startGame, verifyGamePlaying } from './help
  * Full matrix (CD): runs all variants (aggressive, defensive, verify-running).
  */
 test.describe('Automated Playthrough with Governor', () => {
-  test.setTimeout(120000);
+  test.setTimeout(180000);
 
   test('should run automated playthrough with default settings', async ({ page }) => {
     await navigateToGame(page);

--- a/e2e/helpers/game-governor.ts
+++ b/e2e/helpers/game-governor.ts
@@ -5,7 +5,8 @@
  * simulating realistic player behavior and decision-making.
  */
 
-import { expect, type Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { startGame } from './game-helpers';
 
 export interface GovernorConfig {
   /** How aggressively to counter enemies (0-1) */
@@ -39,20 +40,9 @@ export class GameGovernor {
   async start(): Promise<void> {
     this.isRunning = true;
 
-    // Check if game is already running (overlay hidden)
-    const overlay = this.page.locator('#overlay');
-    if (await overlay.isVisible()) {
-      // Use keyboard instead of click because an unhandled font-fetch
-      // rejection from troika-three-text (offline CI) breaks React 18's
-      // synthetic event dispatch for mouse/pointer events while native
-      // keyboard listeners remain unaffected.
-      const startBtn = this.page.locator('#start-btn');
-      await expect(startBtn).toBeVisible();
-      await this.page.keyboard.press(' ');
-
-      // Wait for game to start
-      await expect(this.page.locator('#overlay')).toHaveClass(/hidden/, { timeout: 10000 });
-    }
+    // Use robust startGame helper which handles overlay visibility checks
+    // and retries if necessary
+    await startGame(this.page);
 
     // Start gameplay loop
     await this.playLoop();


### PR DESCRIPTION
This PR addresses CI instability in E2E tests by increasing timeouts for long-running playthroughs and implementing a robust start sequence that retries spacebar presses until the game overlay is confirmed hidden. This prevents failures caused by React event listener hydration delays in slower CI environments.

---
*PR created automatically by Jules for task [4574099222535621716](https://jules.google.com/task/4574099222535621716) started by @jbdevprimary*