### PR TITLE
Fix E2E smoke test race condition in Game component

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,5 +1,5 @@
 import { Canvas } from '@react-three/fiber';
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react';
 import { SFX } from '../lib/audio';
 import { GAME_HEIGHT, GAME_WIDTH, WAVE_ANNOUNCEMENT_DURATION, WAVES } from '../lib/constants';
 import {
@@ -58,7 +58,7 @@ export default function Game() {
   }, [viewport]);
 
   // Initialize responsive viewport
-  useEffect(() => {
+  useLayoutEffect(() => {
     const deviceInfo = detectDevice();
     const initialViewport = calculateViewport(GAME_WIDTH, GAME_HEIGHT, deviceInfo);
     setViewport(initialViewport);
@@ -152,7 +152,7 @@ export default function Game() {
     [handleStartLogic, handleAbility, handleNuke]
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     window.addEventListener('keydown', handleKeyDown);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
Resolved a race condition causing E2E smoke test failures in CI environments.

- Replaced `useEffect` with `useLayoutEffect` for attaching the global `keydown` event listener in `src/components/Game.tsx`. This ensures the listener is active before the initial paint, guaranteeing that Playwright's `toBeVisible` checks (which wait for paint) only pass *after* the listener is attached.
- Replaced `useEffect` with `useLayoutEffect` for viewport initialization to prevent potential layout shifts and ensure correct dimensions before the first paint.
- Verified the fix by running the full E2E smoke test suite locally.
- Cleaned up artifacts directory.

---
*PR created automatically by Jules for task [12967362801421980899](https://jules.google.com/task/12967362801421980899) started by @jbdevprimary*