### PR TITLE
fix(game): robust start logic and e2e test helper

### DIFF
--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -10,7 +10,7 @@ import { expect } from '@playwright/test';
 
 // ─── Timeouts ────────────────────────────────────────────────
 
-export const GAME_START_TIMEOUT = 10000;
+export const GAME_START_TIMEOUT = 15000;
 export const WAVE_ANNOUNCE_TIMEOUT = 15000;
 export const GAMEPLAY_TIMEOUT = 60000;
 export const E2E_PLAYTHROUGH_TIMEOUT = 120000;
@@ -40,6 +40,14 @@ export async function startGame(page: Page): Promise<void> {
   await expect(async () => {
     if (await overlay.isVisible()) {
       await page.keyboard.press(' ');
+      // Also try clicking the button as a fallback if keyboard events are swallowed
+      if (await startBtn.isVisible()) {
+          try {
+            await startBtn.click({ timeout: 500 });
+          } catch {
+            // Ignore click timeout/errors, we rely primarily on keyboard
+          }
+      }
     }
     await expect(overlay).toHaveClass(/hidden/);
   }).toPass({ timeout: GAME_START_TIMEOUT });

--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -42,11 +42,11 @@ export async function startGame(page: Page): Promise<void> {
       await page.keyboard.press(' ');
       // Also try clicking the button as a fallback if keyboard events are swallowed
       if (await startBtn.isVisible()) {
-          try {
-            await startBtn.click({ timeout: 500 });
-          } catch {
-            // Ignore click timeout/errors, we rely primarily on keyboard
-          }
+        try {
+          await startBtn.click({ timeout: 500 });
+        } catch {
+          // Ignore click timeout/errors, we rely primarily on keyboard
+        }
       }
     }
     await expect(overlay).toHaveClass(/hidden/);

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -91,12 +91,18 @@ export default function Game() {
     if (startInitiatedRef.current) return;
     startInitiatedRef.current = true;
 
-    sfxRef.current?.resume();
-    musicRef.current?.resume();
-    sceneRef.current?.reset();
-
+    // Dispatch immediately to update UI state (hide overlay)
     const endless = currentState.win && currentState.screen === 'gameover';
     dispatch(endless ? { type: 'START_ENDLESS' } : { type: 'START_GAME' });
+
+    // Initialize audio/scene, but don't let failures block game start
+    try {
+      sfxRef.current?.resume();
+      musicRef.current?.resume().catch((e) => console.warn('Music resume failed:', e));
+      sceneRef.current?.reset();
+    } catch (e) {
+      console.error('Failed to initialize game components:', e);
+    }
 
     // Delay worker start to let React commit the screen transition first.
     // Without this delay, the worker's rapid STATE messages can race with

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -98,7 +98,7 @@ export default function Game() {
     // Initialize audio/scene, but don't let failures block game start
     // Initialize audio/scene, but don't let failures block game start
     try {
-      sfxRef.current?.resume();
+      sfxRef.current?.resume().catch((e) => console.warn('SFX resume failed:', e));
       sceneRef.current?.reset();
     } catch (e) {
       console.error('Failed to initialize game components:', e);

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -96,13 +96,16 @@ export default function Game() {
     dispatch(endless ? { type: 'START_ENDLESS' } : { type: 'START_GAME' });
 
     // Initialize audio/scene, but don't let failures block game start
+    // Initialize audio/scene, but don't let failures block game start
     try {
       sfxRef.current?.resume();
-      musicRef.current?.resume().catch((e) => console.warn('Music resume failed:', e));
       sceneRef.current?.reset();
     } catch (e) {
       console.error('Failed to initialize game components:', e);
     }
+    
+    // Handle music resume separately since it's async
+    musicRef.current?.resume().catch((e) => console.warn('Music resume failed:', e));
 
     // Delay worker start to let React commit the screen transition first.
     // Without this delay, the worker's rapid STATE messages can race with


### PR DESCRIPTION
This PR fixes a critical issue in the game start sequence where potential errors during audio or scene initialization (common in headless/CI environments) could block the state transition, leaving the overlay visible and causing E2E tests to fail.

Key changes:
1.  **Optimistic UI Update:** Moved `dispatch({ type: 'START_GAME' })` to execute *before* asynchronous side effects like `Tone.js` audio resumption. This ensures the overlay hides immediately regardless of subsequent errors.
2.  **Error Handling:** Added `try/catch` blocks around `sfxRef`, `musicRef`, and `sceneRef` initialization calls, and added `.catch()` to the async `musicRef.current?.resume()` promise to prevent unhandled rejections.
3.  **Robust E2E Helper:** Enhanced `startGame` in `e2e/helpers/game-helpers.ts` to attempt clicking the start button if keyboard events fail (as a fallback) and increased the timeout to 15s to accommodate slower CI environments.

These changes ensure the game fails gracefully if audio cannot start (e.g. autoplay policy) and that E2E tests are less flaky.

---
*PR created automatically by Jules for task [14353397997061994649](https://jules.google.com/task/14353397997061994649) started by @jbdevprimary*