### PR TITLE
fix(e2e): stabilize smoke tests and worker loop

### DIFF
--- a/e2e/device-responsive.spec.ts
+++ b/e2e/device-responsive.spec.ts
@@ -17,6 +17,8 @@ import {
 } from './helpers/game-helpers';
 
 test.describe('Responsive Device Tests', () => {
+  test.setTimeout(120000);
+
   test('should render game canvas on all devices', async ({ page }) => {
     await navigateToGame(page);
     await getCanvasBoundingBox(page);

--- a/e2e/game.spec.ts
+++ b/e2e/game.spec.ts
@@ -8,6 +8,8 @@ import {
 } from './helpers/game-helpers';
 
 test.describe('Psyduck Panic Game', () => {
+  test.setTimeout(120000);
+
   test('should load the game page', async ({ page }) => {
     await navigateToGame(page);
   });

--- a/e2e/helpers/game-helpers.ts
+++ b/e2e/helpers/game-helpers.ts
@@ -10,9 +10,9 @@ import { expect } from '@playwright/test';
 
 // ─── Timeouts ────────────────────────────────────────────────
 
-export const GAME_START_TIMEOUT = 15000;
-export const WAVE_ANNOUNCE_TIMEOUT = 15000;
-export const GAMEPLAY_TIMEOUT = 60000;
+export const GAME_START_TIMEOUT = 60000;
+export const WAVE_ANNOUNCE_TIMEOUT = 60000;
+export const GAMEPLAY_TIMEOUT = 120000;
 export const E2E_PLAYTHROUGH_TIMEOUT = 180000;
 
 // ─── Navigation ──────────────────────────────────────────────
@@ -84,7 +84,7 @@ export async function verifyGamePlaying(page: Page): Promise<void> {
   const timeDisplay = page.locator('#time-display');
   const initialTime = await timeDisplay.textContent();
   await expect
-    .poll(async () => await timeDisplay.textContent(), { timeout: 2500 })
+    .poll(async () => await timeDisplay.textContent(), { timeout: GAME_START_TIMEOUT })
     .not.toBe(initialTime);
 }
 

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -124,7 +124,7 @@ export default function Game() {
       const attemptStart = (retries = 0) => {
         if (workerRef.current) {
           workerRef.current.postMessage({ type: 'START', endless, seed });
-        } else if (retries < 50) {
+        } else if (retries < 250) {
           setTimeout(() => attemptStart(retries + 1), 200);
         }
       };
@@ -186,6 +186,9 @@ export default function Game() {
   useEffect(() => {
     const worker = new GameWorker();
     workerRef.current = worker;
+    worker.onerror = (e) => {
+      console.error('[game.worker] Worker script error:', e.message);
+    };
 
     worker.onmessage = (e: MessageEvent) => {
       const msg = e.data;
@@ -575,6 +578,8 @@ export default function Game() {
             className="start-btn"
             id="start-btn"
             onClick={handleStartButton}
+            // biome-ignore lint/a11y/noAutofocus: ensure keyboard focus for e2e
+            autoFocus={true}
             aria-label={
               ui.screen === 'start'
                 ? 'Start Debate'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,11 +39,6 @@ export default defineConfig({
           ],
 
           // Game logic chunks
-          'game-logic': [
-            './src/lib/game-logic.ts',
-            './src/lib/constants.ts',
-            './src/lib/events.ts',
-          ],
           'game-ecs': ['./src/ecs/world.ts', './src/ecs/react.ts', './src/ecs/state-sync.ts'],
           'game-utils': [
             './src/lib/audio.ts',


### PR DESCRIPTION
- Increase timeouts in `game-helpers.ts` (60s/120s) and test files (120s) to accommodate slow CI runners.
- Replace `requestAnimationFrame` with `setTimeout` in `game.worker.ts` for consistent tick rate in headless environments.
- Relax `dt` clamping in worker to 10 frames (approx 160ms) to prevent time dilation during heavy lag.
- Remove manual `game-logic` chunk in `vite.config.ts` to prevent worker module loading issues in `iife` format.
- Add `autoFocus` to start button in `Game.tsx` for reliable keyboard interaction.
- Increase worker start retry count to 250 (50s) to handle slow initialization.
- Remove `.ci-failure-artifacts/` directory.

---
*PR created automatically by Jules for task [6983683051275897972](https://jules.google.com/task/6983683051275897972) started by @jbdevprimary*