### PR TITLE
feat: post-launch polish — Vite warnings, Koota hooks, lazy load, dep bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,9 @@
     "cap:run:android": "pnpm cap:sync:android && cap run android"
   },
   "dependencies": {
-    "@babylonjs/core": "^8.53.0",
-    "@babylonjs/gui": "^8.53.0",
-    "@babylonjs/havok": "^1.3.11",
-    "@babylonjs/loaders": "^8.53.0",
+    "@babylonjs/core": "^9.2.1",
+    "@babylonjs/gui": "^9.2.1",
+    "@babylonjs/havok": "^1.3.12",
     "@capacitor/android": "^8.3.0",
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.0",
@@ -48,7 +47,7 @@
     "yuka": "^0.7.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.5",
+    "@biomejs/biome": "2.4.11",
     "@capacitor/cli": "^8.3.0",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.1",
@@ -62,9 +61,9 @@
     "@vitest/browser-playwright": "^4.1.4",
     "@vitest/coverage-v8": "^4.0.18",
     "babel-plugin-reactylon": "^1.3.1",
-    "jsdom": "^28.1.0",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vite": "^8.0.8",
     "vitest": "^4.0.18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,14 @@ importers:
   .:
     dependencies:
       '@babylonjs/core':
-        specifier: ^8.53.0
-        version: 8.56.2
+        specifier: ^9.2.1
+        version: 9.2.1
       '@babylonjs/gui':
-        specifier: ^8.53.0
-        version: 8.56.2(@babylonjs/core@8.56.2)
+        specifier: ^9.2.1
+        version: 9.2.1(@babylonjs/core@9.2.1)
       '@babylonjs/havok':
-        specifier: ^1.3.11
+        specifier: ^1.3.12
         version: 1.3.12
-      '@babylonjs/loaders':
-        specifier: ^8.53.0
-        version: 8.56.2(@babylonjs/core@8.56.2)(babylonjs-gltf2interface@8.56.2)
       '@capacitor/android':
         specifier: ^8.3.0
         version: 8.3.0(@capacitor/core@8.3.0)
@@ -61,7 +58,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       reactylon:
         specifier: ^3.5.4
-        version: 3.5.7(@babylonjs/core@8.56.2)(@babylonjs/gui@8.56.2(@babylonjs/core@8.56.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5)
+        version: 3.5.7(@babylonjs/core@9.2.1)(@babylonjs/gui@9.2.1(@babylonjs/core@9.2.1))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5)
       seedrandom:
         specifier: ^3.0.5
         version: 3.0.5
@@ -73,8 +70,8 @@ importers:
         version: 0.7.8
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.5
-        version: 2.4.5
+        specifier: 2.4.11
+        version: 2.4.11
       '@capacitor/cli':
         specifier: ^8.3.0
         version: 8.3.0
@@ -113,27 +110,24 @@ importers:
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
       babel-plugin-reactylon:
         specifier: ^1.3.1
-        version: 1.3.2(@babel/core@7.29.0)(@babylonjs/core@8.56.2)(@babylonjs/gui@8.56.2(@babylonjs/core@8.56.2))(reactylon@3.5.7(@babylonjs/core@8.56.2)(@babylonjs/gui@8.56.2(@babylonjs/core@8.56.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5))
+        version: 1.3.2(@babel/core@7.29.0)(@babylonjs/core@9.2.1)(@babylonjs/gui@9.2.1(@babylonjs/core@9.2.1))(reactylon@3.5.7(@babylonjs/core@9.2.1)(@babylonjs/gui@9.2.1(@babylonjs/core@9.2.1))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5))
       jsdom:
-        specifier: ^28.1.0
-        version: 28.1.0
+        specifier: ^29.0.2
+        version: 29.0.2
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       vite:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
 
 packages:
-
-  '@acemir/cssom@0.9.31':
-    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -143,8 +137,9 @@ packages:
     resolution: {integrity: sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  '@asamuzakjp/dom-selector@6.8.1':
-    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+  '@asamuzakjp/dom-selector@7.0.9':
+    resolution: {integrity: sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
@@ -236,80 +231,74 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@babylonjs/core@8.56.2':
-    resolution: {integrity: sha512-UShs1pt8tSTLYOoITWclXPNrUZUpuHvB2Ur2L1D+uM8c9qaAYOi9gjkurOkQwIlbPGqwQHWImGEyiyix0mQ1dg==}
+  '@babylonjs/core@9.2.1':
+    resolution: {integrity: sha512-G3409wiBQTMJPzbTPV8Lz36cfmCsvp2+7nXYRisnMet1qnelogWXM+XOcZZIzDjMCwV7eII1UzETnnS0GpBfTQ==}
 
-  '@babylonjs/gui@8.56.2':
-    resolution: {integrity: sha512-p1zGvZpxnM6aQbWXWf94Q4TrOZ2VQoMUqeNBTgaGWZ4PhxYyqFU7AN3CaqDjhfn7YTAm/Rjx0E0B5EQMDPsQBA==}
+  '@babylonjs/gui@9.2.1':
+    resolution: {integrity: sha512-PFOHbhfE7R3VMtJskhSkZ6qUJwCFL/piy4nFhDO7V0l7QWTCv3bGu/alx58i8dL4N0qMAydBspiNccYGEXKmMQ==}
     peerDependencies:
-      '@babylonjs/core': ^8.0.0
+      '@babylonjs/core': ^9.0.0
 
   '@babylonjs/havok@1.3.12':
     resolution: {integrity: sha512-KR5Z7DBkVEgdvHLMDh2VWe/nHvUG8+MdLBiAE0iM19KIHAPqPRVITPAZKx4SQusK5nqm4ZXDcKv5OYtViIxLzA==}
-
-  '@babylonjs/loaders@8.56.2':
-    resolution: {integrity: sha512-I2klIhTl4HLVVQEMsBpEh5YqbCCi1hA1oajRVCUcy+9Vfh0owzHEGau0GsVRlAOeYEBDNUrfOj0N6nFGTjNQ6g==}
-    peerDependencies:
-      '@babylonjs/core': ^8.0.0
-      babylonjs-gltf2interface: ^8.0.0
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.4.5':
-    resolution: {integrity: sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ==}
+  '@biomejs/biome@2.4.11':
+    resolution: {integrity: sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.5':
-    resolution: {integrity: sha512-lGS4Nd5O3KQJ6TeWv10mElnx1phERhBxqGP/IKq0SvZl78kcWDFMaTtVK+w3v3lusRFxJY78n07PbKplirsU5g==}
+  '@biomejs/cli-darwin-arm64@2.4.11':
+    resolution: {integrity: sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.5':
-    resolution: {integrity: sha512-6MoH4tyISIBNkZ2Q5T1R7dLd5BsITb2yhhhrU9jHZxnNSNMWl+s2Mxu7NBF8Y3a7JJcqq9nsk8i637z4gqkJxQ==}
+  '@biomejs/cli-darwin-x64@2.4.11':
+    resolution: {integrity: sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.5':
-    resolution: {integrity: sha512-iqLDgpzobG7gpBF0fwEVS/LT8kmN7+S0E2YKFDtqliJfzNLnAiV2Nnyb+ehCDCJgAZBASkYHR2o60VQWikpqIg==}
+  '@biomejs/cli-linux-arm64-musl@2.4.11':
+    resolution: {integrity: sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.5':
-    resolution: {integrity: sha512-U1GAG6FTjhAO04MyH4xn23wRNBkT6H7NentHh+8UxD6ShXKBm5SY4RedKJzkUThANxb9rUKIPc7B8ew9Xo/cWg==}
+  '@biomejs/cli-linux-arm64@2.4.11':
+    resolution: {integrity: sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.5':
-    resolution: {integrity: sha512-NlKa7GpbQmNhZf9kakQeddqZyT7itN7jjWdakELeXyTU3pg/83fTysRRDPJD0akTfKDl6vZYNT9Zqn4MYZVBOA==}
+  '@biomejs/cli-linux-x64-musl@2.4.11':
+    resolution: {integrity: sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.5':
-    resolution: {integrity: sha512-NdODlSugMzTlENPTa4z0xB82dTUlCpsrOxc43///aNkTLblIYH4XpYflBbf5ySlQuP8AA4AZd1qXhV07IdrHdQ==}
+  '@biomejs/cli-linux-x64@2.4.11':
+    resolution: {integrity: sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.5':
-    resolution: {integrity: sha512-EBfrTqRIWOFSd7CQb/0ttjHMR88zm3hGravnDwUA9wHAaCAYsULKDebWcN5RmrEo1KBtl/gDVJMrFjNR0pdGUw==}
+  '@biomejs/cli-win32-arm64@2.4.11':
+    resolution: {integrity: sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.5':
-    resolution: {integrity: sha512-Pmhv9zT95YzECfjEHNl3mN9Vhusw9VA5KHY0ZvlGsxsjwS5cb7vpRnHzJIv0vG7jB0JI7xEaMH9ddfZm/RozBw==}
+  '@biomejs/cli-win32-x64@2.4.11':
+    resolution: {integrity: sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -807,10 +796,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -845,9 +830,6 @@ packages:
       '@babylonjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0
       '@babylonjs/gui': ^7.0.0 || ^8.0.0 || ^9.0.0
       reactylon: ^3.0.0
-
-  babylonjs-gltf2interface@8.56.2:
-    resolution: {integrity: sha512-c2k14C9mPR0pnfksjBdC4uXEos3t2IAYxcMgn5tI1OSC3aDfr6JAq4kADM4gfN9cUo2qIiDdSg6geUVeU8vi6w==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -916,10 +898,6 @@ packages:
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-
-  cssstyle@6.2.0:
-    resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
-    engines: {node: '>=20'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1039,14 +1017,6 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1100,9 +1070,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  jsdom@28.1.0:
-    resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     peerDependencies:
       canvas: ^3.0.0
     peerDependenciesMeta:
@@ -1542,8 +1512,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1749,8 +1719,6 @@ packages:
 
 snapshots:
 
-  '@acemir/cssom@0.9.31': {}
-
   '@alloc/quick-lru@5.2.0': {}
 
   '@asamuzakjp/css-color@5.1.10':
@@ -1760,13 +1728,12 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@asamuzakjp/dom-selector@6.8.1':
+  '@asamuzakjp/dom-selector@7.0.9':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.3.5
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
@@ -1884,56 +1851,51 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@babylonjs/core@8.56.2': {}
+  '@babylonjs/core@9.2.1': {}
 
-  '@babylonjs/gui@8.56.2(@babylonjs/core@8.56.2)':
+  '@babylonjs/gui@9.2.1(@babylonjs/core@9.2.1)':
     dependencies:
-      '@babylonjs/core': 8.56.2
+      '@babylonjs/core': 9.2.1
 
   '@babylonjs/havok@1.3.12':
     dependencies:
       '@types/emscripten': 1.41.5
 
-  '@babylonjs/loaders@8.56.2(@babylonjs/core@8.56.2)(babylonjs-gltf2interface@8.56.2)':
-    dependencies:
-      '@babylonjs/core': 8.56.2
-      babylonjs-gltf2interface: 8.56.2
-
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.4.5':
+  '@biomejs/biome@2.4.11':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.5
-      '@biomejs/cli-darwin-x64': 2.4.5
-      '@biomejs/cli-linux-arm64': 2.4.5
-      '@biomejs/cli-linux-arm64-musl': 2.4.5
-      '@biomejs/cli-linux-x64': 2.4.5
-      '@biomejs/cli-linux-x64-musl': 2.4.5
-      '@biomejs/cli-win32-arm64': 2.4.5
-      '@biomejs/cli-win32-x64': 2.4.5
+      '@biomejs/cli-darwin-arm64': 2.4.11
+      '@biomejs/cli-darwin-x64': 2.4.11
+      '@biomejs/cli-linux-arm64': 2.4.11
+      '@biomejs/cli-linux-arm64-musl': 2.4.11
+      '@biomejs/cli-linux-x64': 2.4.11
+      '@biomejs/cli-linux-x64-musl': 2.4.11
+      '@biomejs/cli-win32-arm64': 2.4.11
+      '@biomejs/cli-win32-x64': 2.4.11
 
-  '@biomejs/cli-darwin-arm64@2.4.5':
+  '@biomejs/cli-darwin-arm64@2.4.11':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.5':
+  '@biomejs/cli-darwin-x64@2.4.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.5':
+  '@biomejs/cli-linux-arm64-musl@2.4.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.5':
+  '@biomejs/cli-linux-arm64@2.4.11':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.5':
+  '@biomejs/cli-linux-x64-musl@2.4.11':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.5':
+  '@biomejs/cli-linux-x64@2.4.11':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.5':
+  '@biomejs/cli-win32-arm64@2.4.11':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.5':
+  '@biomejs/cli-win32-x64@2.4.11':
     optional: true
 
   '@blazediff/core@1.9.1': {}
@@ -2361,7 +2323,7 @@ snapshots:
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -2377,7 +2339,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -2397,7 +2359,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
     optionalDependencies:
       '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))(vitest@4.1.4)
 
@@ -2446,8 +2408,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@7.1.4: {}
-
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -2471,15 +2431,13 @@ snapshots:
       '@babel/runtime': 7.29.2
       tslib: 2.8.1
 
-  babel-plugin-reactylon@1.3.2(@babel/core@7.29.0)(@babylonjs/core@8.56.2)(@babylonjs/gui@8.56.2(@babylonjs/core@8.56.2))(reactylon@3.5.7(@babylonjs/core@8.56.2)(@babylonjs/gui@8.56.2(@babylonjs/core@8.56.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5)):
+  babel-plugin-reactylon@1.3.2(@babel/core@7.29.0)(@babylonjs/core@9.2.1)(@babylonjs/gui@9.2.1(@babylonjs/core@9.2.1))(reactylon@3.5.7(@babylonjs/core@9.2.1)(@babylonjs/gui@9.2.1(@babylonjs/core@9.2.1))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babylonjs/core': 8.56.2
-      '@babylonjs/gui': 8.56.2(@babylonjs/core@8.56.2)
-      reactylon: 3.5.7(@babylonjs/core@8.56.2)(@babylonjs/gui@8.56.2(@babylonjs/core@8.56.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5)
-
-  babylonjs-gltf2interface@8.56.2: {}
+      '@babylonjs/core': 9.2.1
+      '@babylonjs/gui': 9.2.1(@babylonjs/core@9.2.1)
+      reactylon: 3.5.7(@babylonjs/core@9.2.1)(@babylonjs/gui@9.2.1(@babylonjs/core@9.2.1))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5)
 
   balanced-match@4.0.4: {}
 
@@ -2537,13 +2495,6 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
-
-  cssstyle@6.2.0:
-    dependencies:
-      '@asamuzakjp/css-color': 5.1.10
-      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      css-tree: 3.2.1
-      lru-cache: 11.3.5
 
   csstype@3.2.3: {}
 
@@ -2640,20 +2591,6 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  http-proxy-agent@7.0.2:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   inherits@2.0.4: {}
 
   ini@4.1.3: {}
@@ -2696,19 +2633,19 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsdom@28.1.0:
+  jsdom@29.0.2:
     dependencies:
-      '@acemir/cssom': 0.9.31
-      '@asamuzakjp/dom-selector': 6.8.1
+      '@asamuzakjp/css-color': 5.1.10
+      '@asamuzakjp/dom-selector': 7.0.9
       '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
       '@exodus/bytes': 1.15.0
-      cssstyle: 6.2.0
+      css-tree: 3.2.1
       data-urls: 7.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
       parse5: 8.0.0
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -2721,7 +2658,6 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
-      - supports-color
 
   jsesc@3.1.0: {}
 
@@ -2921,10 +2857,10 @@ snapshots:
 
   react@19.2.5: {}
 
-  reactylon@3.5.7(@babylonjs/core@8.56.2)(@babylonjs/gui@8.56.2(@babylonjs/core@8.56.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5):
+  reactylon@3.5.7(@babylonjs/core@9.2.1)(@babylonjs/gui@9.2.1(@babylonjs/core@9.2.1))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-reconciler@0.31.0(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babylonjs/core': 8.56.2
-      '@babylonjs/gui': 8.56.2(@babylonjs/core@8.56.2)
+      '@babylonjs/core': 9.2.1
+      '@babylonjs/gui': 9.2.1(@babylonjs/core@9.2.1)
       acorn: 8.16.0
       its-fine: 1.2.5(@types/react@19.2.14)(react@19.2.5)
       lodash-es: 4.18.1
@@ -3107,7 +3043,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.19.2: {}
 
@@ -3137,7 +3073,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
@@ -3163,7 +3099,7 @@ snapshots:
       '@types/node': 25.6.0
       '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))(vitest@4.1.4)
       '@vitest/coverage-v8': 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
-      jsdom: 28.1.0
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
 

--- a/src/components/__tests__/diegetic-gui.browser.test.tsx
+++ b/src/components/__tests__/diegetic-gui.browser.test.tsx
@@ -1,21 +1,31 @@
 /**
  * Visual isolation test for DiegeticGUI (coherence ring).
+ *
+ * DiegeticGUI reads coherence from the Koota world, so each test sets the
+ * Level trait before mount and resets it after.
  */
 
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import DiegeticGUI from '@/components/diegetic-gui';
+import { useLevelStore } from '@/store/level-store';
 import { mountScene, type SceneHarness } from './helpers/mount-scene';
 
 describe('DiegeticGUI', () => {
   let harness: SceneHarness | null = null;
 
+  beforeEach(() => {
+    useLevelStore.getState().reset();
+  });
+
   afterEach(() => {
     harness?.dispose();
     harness = null;
+    useLevelStore.getState().reset();
   });
 
   test('creates coherence background ring', async () => {
-    harness = await mountScene(<DiegeticGUI coherence={50} />);
+    useLevelStore.setState({ coherence: 50 });
+    harness = await mountScene(<DiegeticGUI />);
     await harness.waitFrames(3);
 
     const names = harness.scene.meshes.map((m) => m.name);
@@ -23,7 +33,8 @@ describe('DiegeticGUI', () => {
   });
 
   test('creates coherence arc at non-zero coherence', async () => {
-    harness = await mountScene(<DiegeticGUI coherence={50} />);
+    useLevelStore.setState({ coherence: 50 });
+    harness = await mountScene(<DiegeticGUI />);
     await harness.waitFrames(3);
 
     const names = harness.scene.meshes.map((m) => m.name);
@@ -31,7 +42,8 @@ describe('DiegeticGUI', () => {
   });
 
   test('arc mesh reflects coherence 100', async () => {
-    harness = await mountScene(<DiegeticGUI coherence={100} />);
+    useLevelStore.setState({ coherence: 100 });
+    harness = await mountScene(<DiegeticGUI />);
     await harness.waitFrames(3);
 
     const arc = harness.scene.getMeshByName('coherenceFgArc');

--- a/src/components/__tests__/full-game-loop.browser.test.tsx
+++ b/src/components/__tests__/full-game-loop.browser.test.tsx
@@ -41,7 +41,7 @@ describe('Full game loop', () => {
         <Platter />
         <PatternStabilizer />
         <EnemySpawner />
-        <DiegeticGUI coherence={25} />
+        <DiegeticGUI />
       </>,
     );
 
@@ -101,7 +101,7 @@ describe('Full game loop', () => {
   });
 
   test('coherence updates on pattern stabilization event', async () => {
-    harness = await mountScene(<DiegeticGUI coherence={25} />);
+    harness = await mountScene(<DiegeticGUI />);
     useGameStore.getState().setPhase('playing');
     await harness.waitFrames(3);
 
@@ -111,7 +111,7 @@ describe('Full game loop', () => {
   });
 
   test('peak coherence tracks the highest ever', async () => {
-    harness = await mountScene(<DiegeticGUI coherence={25} />);
+    harness = await mountScene(<DiegeticGUI />);
     await harness.waitFrames(3);
 
     useLevelStore.getState().addCoherence(50); // 25 → 75

--- a/src/components/__tests__/helpers/mount-scene.tsx
+++ b/src/components/__tests__/helpers/mount-scene.tsx
@@ -5,10 +5,12 @@
  */
 
 import * as BABYLON from '@babylonjs/core';
+import { WorldProvider } from 'koota/react';
 import type { ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Scene } from 'reactylon';
 import { Engine } from 'reactylon/web';
+import { world } from '@/sim/world';
 
 export interface SceneHarness {
   container: HTMLElement;
@@ -38,26 +40,28 @@ export async function mountScene(children: ReactNode): Promise<SceneHarness> {
   const root = createRoot(container);
 
   root.render(
-    <Engine
-      forceWebGL={true}
-      engineOptions={{
-        antialias: false,
-        adaptToDeviceRatio: false,
-        audioEngine: false,
-        preserveDrawingBuffer: true,
-      }}
-    >
-      <Scene
-        onSceneReady={(s) => {
-          capturedScene = s;
-          s.clearColor = new BABYLON.Color4(0, 0, 0, 1);
-          const cam = new BABYLON.ArcRotateCamera('cam', Math.PI / 4, Math.PI / 3, 8, BABYLON.Vector3.Zero(), s);
-          s.activeCamera = cam;
+    <WorldProvider world={world}>
+      <Engine
+        forceWebGL={true}
+        engineOptions={{
+          antialias: false,
+          adaptToDeviceRatio: false,
+          audioEngine: false,
+          preserveDrawingBuffer: true,
         }}
       >
-        {children}
-      </Scene>
-    </Engine>,
+        <Scene
+          onSceneReady={(s) => {
+            capturedScene = s;
+            s.clearColor = new BABYLON.Color4(0, 0, 0, 1);
+            const cam = new BABYLON.ArcRotateCamera('cam', Math.PI / 4, Math.PI / 3, 8, BABYLON.Vector3.Zero(), s);
+            s.activeCamera = cam;
+          }}
+        >
+          {children}
+        </Scene>
+      </Engine>
+    </WorldProvider>,
   );
 
   // Wait for engine to mount and scene to be ready. If setup fails, clean up

--- a/src/components/__tests__/integration.browser.test.tsx
+++ b/src/components/__tests__/integration.browser.test.tsx
@@ -33,7 +33,7 @@ describe('Scene integration', () => {
       <>
         <AISphere reducedMotion={true} />
         <Platter />
-        <DiegeticGUI coherence={50} />
+        <DiegeticGUI />
       </>,
     );
     await harness.waitFrames(3);
@@ -73,7 +73,7 @@ describe('Scene integration', () => {
       <>
         <AISphere reducedMotion={true} />
         <Platter />
-        <DiegeticGUI coherence={50} />
+        <DiegeticGUI />
       </>,
     );
 

--- a/src/components/__tests__/performance.browser.test.tsx
+++ b/src/components/__tests__/performance.browser.test.tsx
@@ -39,7 +39,7 @@ describe('Performance sanity', () => {
       <>
         <AISphere reducedMotion={true} />
         <Platter />
-        <DiegeticGUI coherence={50} />
+        <DiegeticGUI />
         <SPSEnemies />
       </>,
     );

--- a/src/components/__tests__/visual-gallery.browser.test.tsx
+++ b/src/components/__tests__/visual-gallery.browser.test.tsx
@@ -46,7 +46,7 @@ describe('Visual gallery', () => {
   });
 
   test('DiegeticGUI — isolation', async () => {
-    harness = await mountScene(<DiegeticGUI coherence={75} />);
+    harness = await mountScene(<DiegeticGUI />);
     await harness.waitFrames(20);
     expect(harness.scene.getMeshByName('coherenceBgRing')).toBeTruthy();
   });
@@ -83,7 +83,7 @@ describe('Visual gallery', () => {
     harness = await mountScene(
       <>
         <Platter />
-        <DiegeticGUI coherence={50} />
+        <DiegeticGUI />
         <SPSEnemies />
       </>,
     );

--- a/src/components/ai-sphere.tsx
+++ b/src/components/ai-sphere.tsx
@@ -1,4 +1,16 @@
-import * as BABYLON from '@babylonjs/core';
+import {
+  Color3,
+  Color4,
+  DynamicTexture,
+  Material,
+  type Mesh,
+  MeshBuilder,
+  ParticleSystem,
+  PBRMaterial,
+  type Scene,
+  type ShaderMaterial,
+  Vector3,
+} from '@babylonjs/core';
 import gsap from 'gsap';
 import { useCallback, useEffect, useRef } from 'react';
 import { useScene } from 'reactylon';
@@ -17,10 +29,10 @@ interface AISphereProps {
 
 export default function AISphere({ reducedMotion }: AISphereProps) {
   const scene = useScene();
-  const outerSphereRef = useRef<BABYLON.Mesh | null>(null);
-  const innerSphereRef = useRef<BABYLON.Mesh | null>(null);
-  const glassMatRef = useRef<BABYLON.PBRMaterial | null>(null);
-  const innerMatRef = useRef<BABYLON.ShaderMaterial | null>(null);
+  const outerSphereRef = useRef<Mesh | null>(null);
+  const innerSphereRef = useRef<Mesh | null>(null);
+  const glassMatRef = useRef<PBRMaterial | null>(null);
+  const innerMatRef = useRef<ShaderMaterial | null>(null);
   const explodedRef = useRef(false);
   /** Guards against re-triggering clarity while the pulse animation plays */
   const clarityActiveRef = useRef(false);
@@ -41,25 +53,25 @@ export default function AISphere({ reducedMotion }: AISphereProps) {
    * Called on initial mount and on restart after shatter.
    */
   const buildSpheres = useCallback(
-    (scn: BABYLON.Scene) => {
+    (scn: Scene) => {
       // Outer glass sphere
-      const outerSphere = BABYLON.MeshBuilder.CreateSphere('aiSphereOuter', { diameter: 0.52, segments: 64 }, scn);
+      const outerSphere = MeshBuilder.CreateSphere('aiSphereOuter', { diameter: 0.52, segments: 64 }, scn);
       outerSphere.position.y = 0.4;
       outerSphereRef.current = outerSphere;
 
-      const glassMat = new BABYLON.PBRMaterial('glassMat', scn);
-      glassMat.albedoColor = new BABYLON.Color3(0.02, 0.04, 0.09);
+      const glassMat = new PBRMaterial('glassMat', scn);
+      glassMat.albedoColor = new Color3(0.02, 0.04, 0.09);
       glassMat.roughness = 0.02;
       glassMat.metallic = 0.05;
       glassMat.subSurface.isRefractionEnabled = true;
       glassMat.subSurface.indexOfRefraction = 1.52;
       glassMat.alpha = 0.3;
-      glassMat.transparencyMode = BABYLON.Material.MATERIAL_ALPHABLEND;
+      glassMat.transparencyMode = Material.MATERIAL_ALPHABLEND;
       outerSphere.material = glassMat;
       glassMatRef.current = glassMat;
 
       // Inner celestial nebula sphere
-      const innerSphere = BABYLON.MeshBuilder.CreateSphere('aiSphereInner', { diameter: 0.49, segments: 64 }, scn);
+      const innerSphere = MeshBuilder.CreateSphere('aiSphereInner', { diameter: 0.49, segments: 64 }, scn);
       innerSphere.position.y = 0.4;
       innerSphereRef.current = innerSphere;
 
@@ -101,10 +113,10 @@ export default function AISphere({ reducedMotion }: AISphereProps) {
           repeat: 1,
           ease: 'sine.inOut',
           onStart: () => {
-            glassMat.emissiveColor = new BABYLON.Color3(0.1, 0.4, 1.0);
+            glassMat.emissiveColor = new Color3(0.1, 0.4, 1.0);
           },
           onComplete: () => {
-            glassMat.emissiveColor = BABYLON.Color3.Black();
+            glassMat.emissiveColor = Color3.Black();
             glassMat.emissiveIntensity = 0;
           },
         },
@@ -184,7 +196,7 @@ export default function AISphere({ reducedMotion }: AISphereProps) {
 
         // Blue emissive pulse on glass
         if (glassMatRef.current) {
-          glassMatRef.current.emissiveColor = new BABYLON.Color3(0.1, 0.4, 1.0);
+          glassMatRef.current.emissiveColor = new Color3(0.1, 0.4, 1.0);
           gsap.fromTo(
             glassMatRef.current,
             { emissiveIntensity: 0 },
@@ -196,7 +208,7 @@ export default function AISphere({ reducedMotion }: AISphereProps) {
               ease: 'sine.inOut',
               onComplete: () => {
                 if (glassMatRef.current) {
-                  glassMatRef.current.emissiveColor = BABYLON.Color3.Black();
+                  glassMatRef.current.emissiveColor = Color3.Black();
                   glassMatRef.current.emissiveIntensity = 0;
                 }
                 // After the moment passes, entropy resumes
@@ -214,8 +226,8 @@ export default function AISphere({ reducedMotion }: AISphereProps) {
         if (innerMatRef.current) {
           innerMatRef.current.setFloat('u_cloud_density', 2.0);
           innerMatRef.current.setFloat('u_glow_intensity', 3.0);
-          innerMatRef.current.setColor3('u_color1', new BABYLON.Color3(0.03, 0.4, 1.0));
-          innerMatRef.current.setColor3('u_color2', new BABYLON.Color3(0.1, 0.8, 1.0));
+          innerMatRef.current.setColor3('u_color1', new Color3(0.03, 0.4, 1.0));
+          innerMatRef.current.setColor3('u_color2', new Color3(0.1, 0.8, 1.0));
         }
 
         // Dispatch event for gameboard overlay
@@ -230,8 +242,8 @@ export default function AISphere({ reducedMotion }: AISphereProps) {
           mat.setFloat('u_time', t);
           mat.setFloat('u_cloud_density', 2.5 + cur * 3.5);
           mat.setFloat('u_glow_intensity', 1.5 + cur * 2.5);
-          mat.setColor3('u_color1', new BABYLON.Color3(lerp(0.03, 0.9, cur), lerp(0.4, 0.2, cur), lerp(1.0, 0.1, cur)));
-          mat.setColor3('u_color2', new BABYLON.Color3(lerp(0.1, 1.0, cur), lerp(0.8, 0.4, cur), lerp(1.0, 0.2, cur)));
+          mat.setColor3('u_color1', new Color3(lerp(0.03, 0.9, cur), lerp(0.4, 0.2, cur), lerp(1.0, 0.1, cur)));
+          mat.setColor3('u_color2', new Color3(lerp(0.1, 1.0, cur), lerp(0.8, 0.4, cur), lerp(1.0, 0.2, cur)));
         }
 
         // Glass degradation
@@ -267,10 +279,10 @@ export default function AISphere({ reducedMotion }: AISphereProps) {
         // Remove this observer to prevent running on disposed meshes
         scene.onBeforeRenderObservable.remove(observer);
 
-        const emitPos = outerSphereRef.current?.position.clone() ?? BABYLON.Vector3.Zero();
+        const emitPos = outerSphereRef.current?.position.clone() ?? Vector3.Zero();
 
         // Create procedural particle texture (white circle on transparent)
-        const particleTex = new BABYLON.DynamicTexture('shatterTex', 64, scene, false);
+        const particleTex = new DynamicTexture('shatterTex', 64, scene, false);
         const texCtx = particleTex.getContext();
         texCtx.fillStyle = '#ffffff';
         texCtx.beginPath();
@@ -278,20 +290,20 @@ export default function AISphere({ reducedMotion }: AISphereProps) {
         texCtx.fill();
         particleTex.update();
 
-        const shatterParticles = new BABYLON.ParticleSystem('shatter', 1600, scene);
+        const shatterParticles = new ParticleSystem('shatter', 1600, scene);
         shatterParticles.particleTexture = particleTex;
         shatterParticles.emitter = emitPos;
         shatterParticles.minSize = 0.012;
         shatterParticles.maxSize = 0.11;
-        shatterParticles.color1 = new BABYLON.Color4(0.9, 0.3, 0.3, 1);
-        shatterParticles.color2 = new BABYLON.Color4(1.0, 0.6, 0.4, 1);
+        shatterParticles.color1 = new Color4(0.9, 0.3, 0.3, 1);
+        shatterParticles.color2 = new Color4(1.0, 0.6, 0.4, 1);
         shatterParticles.emitRate = 1200;
         shatterParticles.minLifeTime = 0.6;
         shatterParticles.maxLifeTime = 3.2;
-        shatterParticles.direction1 = new BABYLON.Vector3(-8, 4, -8);
-        shatterParticles.direction2 = new BABYLON.Vector3(8, 12, 8);
-        shatterParticles.gravity = new BABYLON.Vector3(0, -15, 0);
-        shatterParticles.createPointEmitter(new BABYLON.Vector3(-0.1, -0.1, -0.1), new BABYLON.Vector3(0.1, 0.1, 0.1));
+        shatterParticles.direction1 = new Vector3(-8, 4, -8);
+        shatterParticles.direction2 = new Vector3(8, 12, 8);
+        shatterParticles.gravity = new Vector3(0, -15, 0);
+        shatterParticles.createPointEmitter(new Vector3(-0.1, -0.1, -0.1), new Vector3(0.1, 0.1, 0.1));
         shatterParticles.start();
         shatterParticles.targetStopDuration = 2.8;
 

--- a/src/components/diegetic-gui.tsx
+++ b/src/components/diegetic-gui.tsx
@@ -1,10 +1,8 @@
-import * as BABYLON from '@babylonjs/core';
+import { Color3, Mesh, MeshBuilder, StandardMaterial, Vector3 } from '@babylonjs/core';
+import { useTrait, useWorld } from 'koota/react';
 import { useEffect, useRef } from 'react';
 import { useScene } from 'reactylon';
-
-interface DiegeticGUIProps {
-  coherence: number;
-}
+import { Level } from '@/sim/world';
 
 /**
  * Diegetic coherence display — a glowing arc ring around the sphere track
@@ -14,20 +12,28 @@ interface DiegeticGUIProps {
  *      fills proportionally with coherence
  *
  * The arc is the only "HUD" — and it's etched into the machine itself.
+ *
+ * Reads coherence directly from the Koota world via useTrait — no prop
+ * drilling from the GameBoard root. The component subscribes only to
+ * Level changes (not Game/Seed/Audio), so it doesn't re-render on
+ * unrelated state churn.
  */
-export default function DiegeticGUI({ coherence }: DiegeticGUIProps) {
+export default function DiegeticGUI() {
   const scene = useScene();
-  const bgRingRef = useRef<BABYLON.Mesh | null>(null);
-  const bgMatRef = useRef<BABYLON.StandardMaterial | null>(null);
-  const fgArcRef = useRef<BABYLON.Mesh | null>(null);
-  const fgMatRef = useRef<BABYLON.StandardMaterial | null>(null);
+  const world = useWorld();
+  const level = useTrait(world, Level);
+  const coherence = level?.coherence ?? 25;
+  const bgRingRef = useRef<Mesh | null>(null);
+  const bgMatRef = useRef<StandardMaterial | null>(null);
+  const fgArcRef = useRef<Mesh | null>(null);
+  const fgMatRef = useRef<StandardMaterial | null>(null);
   const lastArcCoherence = useRef(-1);
 
   // Create background ring (full, dim, always visible)
   useEffect(() => {
     if (!scene) return;
 
-    const bgRing = BABYLON.MeshBuilder.CreateTorus(
+    const bgRing = MeshBuilder.CreateTorus(
       'coherenceBgRing',
       { diameter: 0.84, thickness: 0.02, tessellation: 64 },
       scene,
@@ -36,8 +42,8 @@ export default function DiegeticGUI({ coherence }: DiegeticGUIProps) {
     bgRing.rotation.x = Math.PI / 2;
     bgRingRef.current = bgRing;
 
-    const bgMat = new BABYLON.StandardMaterial('coherenceBgMat', scene);
-    bgMat.emissiveColor = new BABYLON.Color3(0.1, 0.15, 0.2);
+    const bgMat = new StandardMaterial('coherenceBgMat', scene);
+    bgMat.emissiveColor = new Color3(0.1, 0.15, 0.2);
     bgMat.alpha = 0.15;
     bgMat.disableLighting = true;
     bgRing.material = bgMat;
@@ -69,15 +75,15 @@ export default function DiegeticGUI({ coherence }: DiegeticGUIProps) {
     const arcFraction = Math.max(0.01, clampedCoherence / 100);
     const radius = 0.42; // half of diameter 0.84
     const segments = Math.max(4, Math.floor(64 * arcFraction));
-    const path: BABYLON.Vector3[] = [];
+    const path: Vector3[] = [];
     for (let i = 0; i <= segments; i++) {
       const angle = (i / segments) * arcFraction * Math.PI * 2;
-      path.push(new BABYLON.Vector3(Math.cos(angle) * radius, 0, Math.sin(angle) * radius));
+      path.push(new Vector3(Math.cos(angle) * radius, 0, Math.sin(angle) * radius));
     }
 
-    const fgArc = BABYLON.MeshBuilder.CreateTube(
+    const fgArc = MeshBuilder.CreateTube(
       'coherenceFgArc',
-      { path, radius: 0.012, tessellation: 12, cap: BABYLON.Mesh.CAP_ALL },
+      { path, radius: 0.012, tessellation: 12, cap: Mesh.CAP_ALL },
       scene,
     );
     fgArc.position.y = -1.6 + 0.4;
@@ -85,18 +91,14 @@ export default function DiegeticGUI({ coherence }: DiegeticGUIProps) {
 
     // Create or reuse material
     if (!fgMatRef.current) {
-      const fgMat = new BABYLON.StandardMaterial('coherenceFgMat', scene);
+      const fgMat = new StandardMaterial('coherenceFgMat', scene);
       fgMat.disableLighting = true;
       fgMatRef.current = fgMat;
     }
 
     // Color shifts with coherence: low = red-orange, high = bright green-cyan
     const intensity = clampedCoherence / 100;
-    fgMatRef.current.emissiveColor = new BABYLON.Color3(
-      intensity < 0.5 ? 1.0 - intensity : 0,
-      intensity,
-      intensity * 0.6,
-    );
+    fgMatRef.current.emissiveColor = new Color3(intensity < 0.5 ? 1.0 - intensity : 0, intensity, intensity * 0.6);
     fgMatRef.current.alpha = 0.3 + intensity * 0.5;
     fgArc.material = fgMatRef.current;
   }, [scene, coherence]);

--- a/src/components/enemy-spawner.tsx
+++ b/src/components/enemy-spawner.tsx
@@ -1,4 +1,4 @@
-import * as BABYLON from '@babylonjs/core';
+import { Mesh, MeshBuilder, type ShaderMaterial, Vector3 } from '@babylonjs/core';
 import { useEffect, useRef } from 'react';
 import { useScene } from 'reactylon';
 import * as YUKA from 'yuka';
@@ -12,8 +12,8 @@ import { useLevelStore } from '@/store/level-store';
 import { useSeedStore } from '@/store/seed-store';
 
 interface Enemy {
-  mesh: BABYLON.Mesh;
-  material: BABYLON.ShaderMaterial;
+  mesh: Mesh;
+  material: ShaderMaterial;
   speed: number;
   isBoss: boolean;
   health: number;
@@ -58,15 +58,11 @@ export default function EnemySpawner() {
         const startZ = -2 + rng() * 4;
 
         const eid = enemyIdCounter.current++;
-        const plane = BABYLON.MeshBuilder.CreatePlane(
-          `enemy${eid}`,
-          { size: isBossWave && i === 0 ? 2.0 : 1.2 },
-          scene,
-        );
-        plane.position = new BABYLON.Vector3(startX, startY, startZ);
-        plane.billboardMode = BABYLON.Mesh.BILLBOARDMODE_ALL;
+        const plane = MeshBuilder.CreatePlane(`enemy${eid}`, { size: isBossWave && i === 0 ? 2.0 : 1.2 }, scene);
+        plane.position = new Vector3(startX, startY, startZ);
+        plane.billboardMode = Mesh.BILLBOARDMODE_ALL;
 
-        let mat: BABYLON.ShaderMaterial;
+        let mat: ShaderMaterial;
         if (isBossWave && i === 0) {
           mat = createCrystallineCubeMaterial(scene);
           mat.setFloat('u_complexity', 5 + curTension * 5);
@@ -155,9 +151,9 @@ export default function EnemySpawner() {
             for (let s = 0; s < 2; s++) {
               const offset = s === 0 ? 0.3 : -0.3;
               const childId = enemyIdCounter.current++;
-              const childPlane = BABYLON.MeshBuilder.CreatePlane(`splitChild${childId}`, { size: 0.6 }, scene);
-              childPlane.position = new BABYLON.Vector3(splitPos.x + offset, splitPos.y, splitPos.z + offset);
-              childPlane.billboardMode = BABYLON.Mesh.BILLBOARDMODE_ALL;
+              const childPlane = MeshBuilder.CreatePlane(`splitChild${childId}`, { size: 0.6 }, scene);
+              childPlane.position = new Vector3(splitPos.x + offset, splitPos.y, splitPos.z + offset);
+              childPlane.billboardMode = Mesh.BILLBOARDMODE_ALL;
 
               const childMat = createNeonRaymarcherMaterial(scene);
               childMat.setFloat('u_amount', 2);

--- a/src/components/game-scene.tsx
+++ b/src/components/game-scene.tsx
@@ -1,4 +1,4 @@
-import * as BABYLON from '@babylonjs/core';
+import { ArcRotateCamera, type Scene as BabylonScene, Color3, Color4, Vector3 } from '@babylonjs/core';
 import { Scene } from 'reactylon';
 import { Engine } from 'reactylon/web';
 import AISphere from '@/components/ai-sphere';
@@ -14,26 +14,20 @@ import SPSEnemies from '@/components/sps-enemies';
 import XRSession from '@/components/xr-session';
 
 interface GameSceneProps {
-  coherence: number;
   reducedMotion: boolean;
 }
 
-function SceneContent({ coherence, reducedMotion }: { coherence: number; reducedMotion: boolean }) {
+function SceneContent({ reducedMotion }: { reducedMotion: boolean }) {
   return (
     <>
       {/* Lighting */}
-      <hemisphericLight name="hemiLight" direction={new BABYLON.Vector3(0, 1, 0)} intensity={0.3} />
-      <pointLight
-        name="rimLight"
-        position={new BABYLON.Vector3(0, 2, 3)}
-        intensity={2}
-        diffuse={new BABYLON.Color3(0.3, 0.5, 0.8)}
-      />
+      <hemisphericLight name="hemiLight" direction={new Vector3(0, 1, 0)} intensity={0.3} />
+      <pointLight name="rimLight" position={new Vector3(0, 2, 3)} intensity={2} diffuse={new Color3(0.3, 0.5, 0.8)} />
       <pointLight
         name="keyLight"
-        position={new BABYLON.Vector3(3, 5, -4)}
+        position={new Vector3(3, 5, -4)}
         intensity={1.8}
-        diffuse={new BABYLON.Color3(0.9, 0.9, 1.0)}
+        diffuse={new Color3(0.9, 0.9, 1.0)}
       />
 
       {/* Camera is created procedurally in onSceneReady to ensure it's active before first render */}
@@ -46,11 +40,12 @@ function SceneContent({ coherence, reducedMotion }: { coherence: number; reduced
       <PatternStabilizer />
       <EnemySpawner />
 
-      {/* Polish systems */}
+      {/* Polish systems — DiegeticGUI reads coherence from Koota directly,
+          no prop drilling needed. */}
       <PostProcessCorruption reducedMotion={reducedMotion} />
       <SpatialAudio />
       <SPSEnemies />
-      <DiegeticGUI coherence={coherence} />
+      <DiegeticGUI />
       <AudioEngineSystem />
       <PhysicsKeys />
       <XRSession />
@@ -58,7 +53,7 @@ function SceneContent({ coherence, reducedMotion }: { coherence: number; reduced
   );
 }
 
-export default function GameScene({ coherence, reducedMotion }: GameSceneProps) {
+export default function GameScene({ reducedMotion }: GameSceneProps) {
   return (
     <Engine
       forceWebGL={true}
@@ -72,7 +67,7 @@ export default function GameScene({ coherence, reducedMotion }: GameSceneProps) 
     >
       <Scene
         onSceneReady={(scene) => {
-          scene.clearColor = new BABYLON.Color4(0.04, 0.04, 0.06, 1);
+          scene.clearColor = new Color4(0.04, 0.04, 0.06, 1);
 
           const engine = scene.getEngine();
           const canvas = engine.getRenderingCanvas();
@@ -89,12 +84,12 @@ export default function GameScene({ coherence, reducedMotion }: GameSceneProps) 
           };
 
           const initial = computeFraming();
-          const camera = new BABYLON.ArcRotateCamera(
+          const camera = new ArcRotateCamera(
             'camera',
             Math.PI / 4,
             initial.beta,
             initial.radius,
-            BABYLON.Vector3.Zero(),
+            Vector3.Zero(),
             scene,
           );
           camera.lowerRadiusLimit = 4;
@@ -127,7 +122,7 @@ export default function GameScene({ coherence, reducedMotion }: GameSceneProps) 
           // Only clear the reference if this scene still owns it (protects
           // against overlapping scene lifetimes during test teardown).
           if (typeof globalThis !== 'undefined' && process.env.NODE_ENV !== 'production') {
-            const g = globalThis as unknown as { __scene?: BABYLON.Scene };
+            const g = globalThis as unknown as { __scene?: BabylonScene };
             g.__scene = scene;
             scene.onDisposeObservable.addOnce(() => {
               if (g.__scene === scene) delete g.__scene;
@@ -135,7 +130,7 @@ export default function GameScene({ coherence, reducedMotion }: GameSceneProps) 
           }
         }}
       >
-        <SceneContent coherence={coherence} reducedMotion={reducedMotion} />
+        <SceneContent reducedMotion={reducedMotion} />
       </Scene>
     </Engine>
   );

--- a/src/components/gameboard.tsx
+++ b/src/components/gameboard.tsx
@@ -1,12 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import GameScene from '@/components/game-scene';
+import { useTrait, useWorld } from 'koota/react';
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import ATCShader from '@/components/ui/atc-shader';
 import { loadHighScore, saveHighScore } from '@/lib/high-score';
+import { Level } from '@/sim/world';
 import { useAudioStore } from '@/store/audio-store';
 import { useGameStore } from '@/store/game-store';
 import { useInputStore } from '@/store/input-store';
 import { useLevelStore } from '@/store/level-store';
 import { useSeedStore } from '@/store/seed-store';
+
+// Lazy-load GameScene so the Babylon chunk (~1.5MB gz) doesn't block the
+// initial paint. The "INITIALIZING CORE" overlay covers the load.
+const GameScene = lazy(() => import('@/components/game-scene'));
 
 export default function GameBoard() {
   // ── Overlay states ──
@@ -86,8 +91,11 @@ export default function GameBoard() {
   const [srAnnouncement, setSrAnnouncement] = useState('');
   const lastAnnouncedTension = useRef(0);
 
-  const tension = useLevelStore((s) => s.tension);
-  const coherence = useLevelStore((s) => s.coherence);
+  // Read tension reactively from Koota — same selector behavior as the
+  // shim, just one fewer translation layer.
+  const world = useWorld();
+  const level = useTrait(world, Level);
+  const tension = level?.tension ?? 0;
   const initialize = useAudioStore((s) => s.initialize);
   const _phase = useGameStore((s) => s.phase);
 
@@ -345,9 +353,12 @@ export default function GameBoard() {
         </div>
       )}
 
-      {/* 3D Game Layer */}
+      {/* 3D Game Layer — Suspense fallback is null because the loading
+          overlay above (z-40) covers everything until the scene is ready. */}
       <div className="absolute inset-0 z-10" style={{ touchAction: 'none' }}>
-        <GameScene coherence={coherence} reducedMotion={reducedMotion} />
+        <Suspense fallback={null}>
+          <GameScene reducedMotion={reducedMotion} />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/components/pattern-stabilizer.tsx
+++ b/src/components/pattern-stabilizer.tsx
@@ -1,4 +1,4 @@
-import * as BABYLON from '@babylonjs/core';
+import { type Color3, Color4, ParticleSystem, Vector3 } from '@babylonjs/core';
 import { useEffect, useRef } from 'react';
 import { useScene } from 'reactylon';
 import { world } from '@/game/world';
@@ -12,11 +12,11 @@ import { useSeedStore } from '@/store/seed-store';
 interface Pattern {
   id: number;
   colorIndex: number;
-  color: BABYLON.Color3;
+  color: Color3;
   progress: number;
   speed: number;
   angle: number;
-  particleSystem: BABYLON.ParticleSystem;
+  particleSystem: ParticleSystem;
   entity: import('@/game/world').GameEntity;
 }
 
@@ -49,16 +49,16 @@ export default function PatternStabilizer() {
       const speed = 0.3 + rng() * curTension * 1.2;
       const patternId = idCounter.current++;
 
-      const ps = new BABYLON.ParticleSystem(`pattern${patternId}`, 60, scene);
-      ps.emitter = new BABYLON.Vector3(0, 0.4, 0);
+      const ps = new ParticleSystem(`pattern${patternId}`, 60, scene);
+      ps.emitter = new Vector3(0, 0.4, 0);
       ps.minSize = 0.015;
       ps.maxSize = 0.045;
-      ps.color1 = new BABYLON.Color4(color.r, color.g, color.b, 1);
-      ps.color2 = new BABYLON.Color4(color.r * 0.5, color.g * 0.5, color.b * 0.5, 0.5);
+      ps.color1 = new Color4(color.r, color.g, color.b, 1);
+      ps.color2 = new Color4(color.r * 0.5, color.g * 0.5, color.b * 0.5, 0.5);
       ps.emitRate = 70;
       ps.minLifeTime = 1.8;
       ps.maxLifeTime = 3.2;
-      ps.createPointEmitter(new BABYLON.Vector3(-0.05, -0.05, -0.05), new BABYLON.Vector3(0.05, 0.05, 0.05));
+      ps.createPointEmitter(new Vector3(-0.05, -0.05, -0.05), new Vector3(0.05, 0.05, 0.05));
       ps.start();
 
       const entity = world.add({
@@ -97,7 +97,7 @@ export default function PatternStabilizer() {
         p.progress += p.speed * dt;
 
         const radius = p.progress * 0.52;
-        p.particleSystem.emitter = new BABYLON.Vector3(Math.cos(p.angle) * radius, 0.4, Math.sin(p.angle) * radius);
+        p.particleSystem.emitter = new Vector3(Math.cos(p.angle) * radius, 0.4, Math.sin(p.angle) * radius);
 
         if (heldKeycaps.has(p.colorIndex)) {
           p.progress = Math.max(0, p.progress - 2.4 * dt);

--- a/src/components/physics-keys.tsx
+++ b/src/components/physics-keys.tsx
@@ -1,14 +1,27 @@
-import * as BABYLON from '@babylonjs/core';
+import {
+  HavokPlugin,
+  type Mesh,
+  MeshBuilder,
+  Physics6DoFConstraint,
+  PhysicsBody,
+  PhysicsConstraintAxis,
+  PhysicsConstraintMotorType,
+  PhysicsMotionType,
+  type PhysicsShape,
+  PhysicsShapeBox,
+  Quaternion,
+  Vector3,
+} from '@babylonjs/core';
 import { useEffect, useRef } from 'react';
 import { useScene } from 'reactylon';
 
 interface KeyPhysicsBinding {
-  body: BABYLON.PhysicsBody;
-  anchorBody: BABYLON.PhysicsBody;
-  constraint: BABYLON.Physics6DoFConstraint;
-  shape: BABYLON.PhysicsShape;
-  anchorShape: BABYLON.PhysicsShape;
-  anchorMesh: BABYLON.Mesh;
+  body: PhysicsBody;
+  anchorBody: PhysicsBody;
+  constraint: Physics6DoFConstraint;
+  shape: PhysicsShape;
+  anchorShape: PhysicsShape;
+  anchorMesh: Mesh;
 }
 
 /**
@@ -22,7 +35,7 @@ interface KeyPhysicsBinding {
  */
 export default function PhysicsKeys() {
   const scene = useScene();
-  const pluginRef = useRef<BABYLON.HavokPlugin | null>(null);
+  const pluginRef = useRef<HavokPlugin | null>(null);
   const bindingsRef = useRef<KeyPhysicsBinding[]>([]);
   const disposedRef = useRef(false);
 
@@ -49,8 +62,8 @@ export default function PhysicsKeys() {
 
         if (disposedRef.current) return;
 
-        const plugin = new BABYLON.HavokPlugin(true, havokInstance);
-        scene.enablePhysics(new BABYLON.Vector3(0, -9.81, 0), plugin);
+        const plugin = new HavokPlugin(true, havokInstance);
+        scene.enablePhysics(new Vector3(0, -9.81, 0), plugin);
         pluginRef.current = plugin;
 
         scene.onAfterRenderObservable.addOnce(() => {
@@ -61,21 +74,21 @@ export default function PhysicsKeys() {
           );
 
           for (const mesh of keycapMeshes) {
-            let body: BABYLON.PhysicsBody | null = null;
-            let anchorBody: BABYLON.PhysicsBody | null = null;
-            let constraint: BABYLON.Physics6DoFConstraint | null = null;
-            let shape: BABYLON.PhysicsShape | null = null;
-            let anchorShape: BABYLON.PhysicsShape | null = null;
-            let anchorMesh: BABYLON.Mesh | null = null;
+            let body: PhysicsBody | null = null;
+            let anchorBody: PhysicsBody | null = null;
+            let constraint: Physics6DoFConstraint | null = null;
+            let shape: PhysicsShape | null = null;
+            let anchorShape: PhysicsShape | null = null;
+            let anchorMesh: Mesh | null = null;
 
             try {
-              body = new BABYLON.PhysicsBody(mesh, BABYLON.PhysicsMotionType.DYNAMIC, false, scene);
+              body = new PhysicsBody(mesh, PhysicsMotionType.DYNAMIC, false, scene);
 
               const extents = mesh.getBoundingInfo().boundingBox.extendSize.scale(2);
-              shape = new BABYLON.PhysicsShapeBox(
-                BABYLON.Vector3.Zero(),
-                BABYLON.Quaternion.Identity(),
-                new BABYLON.Vector3(extents.x, extents.y, extents.z),
+              shape = new PhysicsShapeBox(
+                Vector3.Zero(),
+                Quaternion.Identity(),
+                new Vector3(extents.x, extents.y, extents.z),
                 scene,
               );
               shape.material = { friction: 0.6, restitution: 0.05 };
@@ -84,58 +97,55 @@ export default function PhysicsKeys() {
               body.setLinearDamping(4);
               body.setAngularDamping(12);
 
-              anchorMesh = BABYLON.MeshBuilder.CreateBox(`${mesh.name}_anchor`, { size: 0.01 }, scene);
+              anchorMesh = MeshBuilder.CreateBox(`${mesh.name}_anchor`, { size: 0.01 }, scene);
               const worldPos = mesh.getAbsolutePosition();
-              const worldRotation = BABYLON.Quaternion.FromRotationMatrix(mesh.getWorldMatrix().getRotationMatrix());
+              const worldRotation = Quaternion.FromRotationMatrix(mesh.getWorldMatrix().getRotationMatrix());
               anchorMesh.position.copyFrom(worldPos);
               anchorMesh.rotationQuaternion = worldRotation;
               anchorMesh.isVisible = false;
               anchorMesh.isPickable = false;
               anchorMesh.parent = null;
 
-              anchorBody = new BABYLON.PhysicsBody(anchorMesh, BABYLON.PhysicsMotionType.STATIC, false, scene);
-              anchorShape = new BABYLON.PhysicsShapeBox(
-                BABYLON.Vector3.Zero(),
-                BABYLON.Quaternion.Identity(),
-                new BABYLON.Vector3(0.01, 0.01, 0.01),
+              anchorBody = new PhysicsBody(anchorMesh, PhysicsMotionType.STATIC, false, scene);
+              anchorShape = new PhysicsShapeBox(
+                Vector3.Zero(),
+                Quaternion.Identity(),
+                new Vector3(0.01, 0.01, 0.01),
                 scene,
               );
               anchorBody.shape = anchorShape;
 
-              constraint = new BABYLON.Physics6DoFConstraint(
+              constraint = new Physics6DoFConstraint(
                 {
-                  pivotA: BABYLON.Vector3.Zero(),
-                  pivotB: BABYLON.Vector3.Zero(),
-                  axisA: BABYLON.Vector3.Right(),
-                  axisB: BABYLON.Vector3.Right(),
-                  perpAxisA: BABYLON.Vector3.Forward(),
-                  perpAxisB: BABYLON.Vector3.Forward(),
+                  pivotA: Vector3.Zero(),
+                  pivotB: Vector3.Zero(),
+                  axisA: Vector3.Right(),
+                  axisB: Vector3.Right(),
+                  perpAxisA: Vector3.Forward(),
+                  perpAxisB: Vector3.Forward(),
                   collision: false,
                 },
                 [
-                  { axis: BABYLON.PhysicsConstraintAxis.LINEAR_X, minLimit: 0, maxLimit: 0 },
+                  { axis: PhysicsConstraintAxis.LINEAR_X, minLimit: 0, maxLimit: 0 },
                   {
-                    axis: BABYLON.PhysicsConstraintAxis.LINEAR_Y,
+                    axis: PhysicsConstraintAxis.LINEAR_Y,
                     minLimit: -0.055,
                     maxLimit: 0.006,
                     stiffness: 300,
                     damping: 32,
                   },
-                  { axis: BABYLON.PhysicsConstraintAxis.LINEAR_Z, minLimit: 0, maxLimit: 0 },
-                  { axis: BABYLON.PhysicsConstraintAxis.ANGULAR_X, minLimit: 0, maxLimit: 0 },
-                  { axis: BABYLON.PhysicsConstraintAxis.ANGULAR_Y, minLimit: 0, maxLimit: 0 },
-                  { axis: BABYLON.PhysicsConstraintAxis.ANGULAR_Z, minLimit: 0, maxLimit: 0 },
+                  { axis: PhysicsConstraintAxis.LINEAR_Z, minLimit: 0, maxLimit: 0 },
+                  { axis: PhysicsConstraintAxis.ANGULAR_X, minLimit: 0, maxLimit: 0 },
+                  { axis: PhysicsConstraintAxis.ANGULAR_Y, minLimit: 0, maxLimit: 0 },
+                  { axis: PhysicsConstraintAxis.ANGULAR_Z, minLimit: 0, maxLimit: 0 },
                 ],
                 scene,
               );
 
               body.addConstraint(anchorBody, constraint);
-              constraint.setAxisMotorType(
-                BABYLON.PhysicsConstraintAxis.LINEAR_Y,
-                BABYLON.PhysicsConstraintMotorType.POSITION,
-              );
-              constraint.setAxisMotorTarget(BABYLON.PhysicsConstraintAxis.LINEAR_Y, 0);
-              constraint.setAxisMotorMaxForce(BABYLON.PhysicsConstraintAxis.LINEAR_Y, 45);
+              constraint.setAxisMotorType(PhysicsConstraintAxis.LINEAR_Y, PhysicsConstraintMotorType.POSITION);
+              constraint.setAxisMotorTarget(PhysicsConstraintAxis.LINEAR_Y, 0);
+              constraint.setAxisMotorMaxForce(PhysicsConstraintAxis.LINEAR_Y, 45);
 
               bindingsRef.current.push({
                 body,

--- a/src/components/platter.tsx
+++ b/src/components/platter.tsx
@@ -1,4 +1,18 @@
-import * as BABYLON from '@babylonjs/core';
+import {
+  ActionManager,
+  Color3,
+  Color4,
+  DynamicTexture,
+  ExecuteCodeAction,
+  type Mesh,
+  MeshBuilder,
+  ParticleSystem,
+  PBRMaterial,
+  PointLight,
+  type Scene,
+  TransformNode,
+  Vector3,
+} from '@babylonjs/core';
 import gsap from 'gsap';
 import { CustomEase } from 'gsap/CustomEase';
 import { useEffect, useRef } from 'react';
@@ -19,52 +33,48 @@ CustomEase.create('gearWobble', 'M0,0 C0.18,0.35 0.35,0.72 0.52,0.48 0.68,0.25 0
 
 export default function Platter() {
   const scene = useScene();
-  const platterGroupRef = useRef<BABYLON.TransformNode | null>(null);
-  const playTopRef = useRef<BABYLON.Mesh | null>(null);
-  const playBottomRef = useRef<BABYLON.Mesh | null>(null);
-  const continueTopRef = useRef<BABYLON.Mesh | null>(null);
-  const continueBottomRef = useRef<BABYLON.Mesh | null>(null);
-  const recessLightRef = useRef<BABYLON.PointLight | null>(null);
-  const rimMatRef = useRef<BABYLON.PBRMaterial | null>(null);
-  const keycapMeshes = useRef<BABYLON.Mesh[]>([]);
+  const platterGroupRef = useRef<TransformNode | null>(null);
+  const playTopRef = useRef<Mesh | null>(null);
+  const playBottomRef = useRef<Mesh | null>(null);
+  const continueTopRef = useRef<Mesh | null>(null);
+  const continueBottomRef = useRef<Mesh | null>(null);
+  const recessLightRef = useRef<PointLight | null>(null);
+  const rimMatRef = useRef<PBRMaterial | null>(null);
+  const keycapMeshes = useRef<Mesh[]>([]);
 
   const { generateNewSeed, replayLastSeed } = useSeedStore.getState();
 
   useEffect(() => {
     if (!scene) return;
 
-    const platterGroup = new BABYLON.TransformNode('platterRoot', scene);
+    const platterGroup = new TransformNode('platterRoot', scene);
     platterGroup.position.y = -1.6;
     platterGroupRef.current = platterGroup;
 
     // Heavy black metal platter base
-    const baseMat = new BABYLON.PBRMaterial('platterBaseMat', scene);
-    baseMat.albedoColor = new BABYLON.Color3(0.08, 0.08, 0.1);
+    const baseMat = new PBRMaterial('platterBaseMat', scene);
+    baseMat.albedoColor = new Color3(0.08, 0.08, 0.1);
     baseMat.metallic = 0.92;
     baseMat.roughness = 0.28;
 
-    const base = BABYLON.MeshBuilder.CreateCylinder(
-      'platterBase',
-      { height: 0.32, diameter: 3, tessellation: 64 },
-      scene,
-    );
+    const base = MeshBuilder.CreateCylinder('platterBase', { height: 0.32, diameter: 3, tessellation: 64 }, scene);
     base.material = baseMat;
     base.parent = platterGroup;
 
     // Thick industrial rim
-    const rimMat = new BABYLON.PBRMaterial('rimMat', scene);
-    rimMat.albedoColor = new BABYLON.Color3(0.06, 0.06, 0.08);
+    const rimMat = new PBRMaterial('rimMat', scene);
+    rimMat.albedoColor = new Color3(0.06, 0.06, 0.08);
     rimMat.metallic = 0.96;
     rimMat.roughness = 0.18;
-    rimMat.emissiveColor = new BABYLON.Color3(0, 0.13, 0.3);
+    rimMat.emissiveColor = new Color3(0, 0.13, 0.3);
 
-    const rim = BABYLON.MeshBuilder.CreateCylinder('rim', { height: 0.2, diameter: 3.2, tessellation: 64 }, scene);
+    const rim = MeshBuilder.CreateCylinder('rim', { height: 0.2, diameter: 3.2, tessellation: 64 }, scene);
     rim.position.y = 0.15;
     rim.material = rimMat;
     rim.parent = platterGroup;
 
     // "MAINTAIN COHERENCE" etched text on rim — glows brighter with tension
-    const rimTextTex = new BABYLON.DynamicTexture('rimTextTex', { width: 1024, height: 128 }, scene, false);
+    const rimTextTex = new DynamicTexture('rimTextTex', { width: 1024, height: 128 }, scene, false);
     const rimTextCtx = rimTextTex.getContext() as unknown as CanvasRenderingContext2D;
     rimTextCtx.clearRect(0, 0, 1024, 128);
     rimTextCtx.font = '24px Courier New';
@@ -79,51 +89,47 @@ export default function Platter() {
     rimMatRef.current = rimMat;
 
     // Recessed circular track for sphere
-    const trackMat = new BABYLON.PBRMaterial('trackMat', scene);
-    trackMat.albedoColor = new BABYLON.Color3(0.07, 0.07, 0.09);
+    const trackMat = new PBRMaterial('trackMat', scene);
+    trackMat.albedoColor = new Color3(0.07, 0.07, 0.09);
     trackMat.metallic = 0.82;
     trackMat.roughness = 0.38;
 
-    const track = BABYLON.MeshBuilder.CreateCylinder(
-      'track',
-      { height: 0.25, diameter: 0.78, tessellation: 64 },
-      scene,
-    );
+    const track = MeshBuilder.CreateCylinder('track', { height: 0.25, diameter: 0.78, tessellation: 64 }, scene);
     track.position.y = 0.4;
     track.material = trackMat;
     track.parent = platterGroup;
 
     // Garage door panels for play key
-    const panelMat = new BABYLON.PBRMaterial('panelMat', scene);
-    panelMat.albedoColor = new BABYLON.Color3(0.06, 0.06, 0.08);
+    const panelMat = new PBRMaterial('panelMat', scene);
+    panelMat.albedoColor = new Color3(0.06, 0.06, 0.08);
     panelMat.metallic = 0.95;
     panelMat.roughness = 0.25;
-    panelMat.emissiveColor = new BABYLON.Color3(0.04, 0.15, 0.3);
+    panelMat.emissiveColor = new Color3(0.04, 0.15, 0.3);
 
     const createGarageDoor = (name: string, posX: number, posZ: number, rotY: number) => {
-      const parent = new BABYLON.TransformNode(`${name}Parent`, scene);
-      parent.position = new BABYLON.Vector3(posX, 0, posZ);
+      const parent = new TransformNode(`${name}Parent`, scene);
+      parent.position = new Vector3(posX, 0, posZ);
       parent.rotation.y = rotY;
       parent.parent = platterGroup;
 
-      const top = BABYLON.MeshBuilder.CreateBox(`${name}Top`, { width: 0.25, height: 0.12, depth: 0.18 }, scene);
+      const top = MeshBuilder.CreateBox(`${name}Top`, { width: 0.25, height: 0.12, depth: 0.18 }, scene);
       top.position.y = 0.021;
       top.material = panelMat;
       top.parent = parent;
 
-      const bottom = BABYLON.MeshBuilder.CreateBox(`${name}Bottom`, { width: 0.25, height: 0.12, depth: 0.18 }, scene);
+      const bottom = MeshBuilder.CreateBox(`${name}Bottom`, { width: 0.25, height: 0.12, depth: 0.18 }, scene);
       bottom.position.y = -0.021;
       bottom.material = panelMat;
       bottom.parent = parent;
 
       // Keycap (hidden inside until door opens)
-      const keycapMat = new BABYLON.PBRMaterial(`${name}KeycapMat`, scene);
-      keycapMat.albedoColor = new BABYLON.Color3(0.1, 0.1, 0.12);
+      const keycapMat = new PBRMaterial(`${name}KeycapMat`, scene);
+      keycapMat.albedoColor = new Color3(0.1, 0.1, 0.12);
       keycapMat.metallic = 0.8;
       keycapMat.roughness = 0.3;
-      keycapMat.emissiveColor = new BABYLON.Color3(0.04, 0.2, 0.4);
+      keycapMat.emissiveColor = new Color3(0.04, 0.2, 0.4);
 
-      const keycap = BABYLON.MeshBuilder.CreateBox(`${name}Keycap`, { width: 0.15, height: 0.08, depth: 0.15 }, scene);
+      const keycap = MeshBuilder.CreateBox(`${name}Keycap`, { width: 0.15, height: 0.08, depth: 0.15 }, scene);
       keycap.position.y = 0.05;
       keycap.material = keycapMat;
       keycap.parent = parent;
@@ -140,54 +146,54 @@ export default function Platter() {
     continueBottomRef.current = continueDoor.bottom;
 
     // Click handlers
-    playDoor.keycap.actionManager = new BABYLON.ActionManager(scene);
+    playDoor.keycap.actionManager = new ActionManager(scene);
     playDoor.keycap.actionManager.registerAction(
-      new BABYLON.ExecuteCodeAction(BABYLON.ActionManager.OnPickTrigger, () => generateNewSeed()),
+      new ExecuteCodeAction(ActionManager.OnPickTrigger, () => generateNewSeed()),
     );
 
-    continueDoor.keycap.actionManager = new BABYLON.ActionManager(scene);
+    continueDoor.keycap.actionManager = new ActionManager(scene);
     continueDoor.keycap.actionManager.registerAction(
-      new BABYLON.ExecuteCodeAction(BABYLON.ActionManager.OnPickTrigger, () => replayLastSeed()),
+      new ExecuteCodeAction(ActionManager.OnPickTrigger, () => replayLastSeed()),
     );
 
     // Center pause keycap
-    const pauseMat = new BABYLON.PBRMaterial('pauseKeyMat', scene);
-    pauseMat.albedoColor = new BABYLON.Color3(0.15, 0.08, 0.02);
+    const pauseMat = new PBRMaterial('pauseKeyMat', scene);
+    pauseMat.albedoColor = new Color3(0.15, 0.08, 0.02);
     pauseMat.metallic = 0.8;
     pauseMat.roughness = 0.3;
-    pauseMat.emissiveColor = new BABYLON.Color3(0.4, 0.15, 0.02);
+    pauseMat.emissiveColor = new Color3(0.4, 0.15, 0.02);
 
-    const pauseKey = BABYLON.MeshBuilder.CreateBox('pauseKey', { width: 0.18, height: 0.1, depth: 0.18 }, scene);
-    pauseKey.position = new BABYLON.Vector3(0, 0, -1.4);
+    const pauseKey = MeshBuilder.CreateBox('pauseKey', { width: 0.18, height: 0.1, depth: 0.18 }, scene);
+    pauseKey.position = new Vector3(0, 0, -1.4);
     pauseKey.material = pauseMat;
     pauseKey.parent = platterGroup;
     pauseKey.isPickable = true;
 
-    pauseKey.actionManager = new BABYLON.ActionManager(scene);
+    pauseKey.actionManager = new ActionManager(scene);
     pauseKey.actionManager.registerAction(
-      new BABYLON.ExecuteCodeAction(BABYLON.ActionManager.OnPickTrigger, () => {
+      new ExecuteCodeAction(ActionManager.OnPickTrigger, () => {
         useGameStore.getState().togglePause();
       }),
     );
 
     // Decorative keycaps around the rim — each gets a unique color from the palette
-    const decorKeys: BABYLON.Mesh[] = [];
-    const keycapMaterials: BABYLON.PBRMaterial[] = [];
+    const decorKeys: Mesh[] = [];
+    const keycapMaterials: PBRMaterial[] = [];
 
     for (let i = 0; i < 12; i++) {
       const side = i < 6 ? -1 : 1;
       const idx = i < 6 ? i : i - 6;
       const angle = side * (0.4 + idx * 0.18);
-      const key = BABYLON.MeshBuilder.CreateBox(`decorKey${i}`, { width: 0.12, height: 0.08, depth: 0.12 }, scene);
-      key.position = new BABYLON.Vector3(Math.sin(angle) * 1.4, 0, Math.cos(angle) * 1.4 - 0.35);
+      const key = MeshBuilder.CreateBox(`decorKey${i}`, { width: 0.12, height: 0.08, depth: 0.12 }, scene);
+      key.position = new Vector3(Math.sin(angle) * 1.4, 0, Math.cos(angle) * 1.4 - 0.35);
       key.rotation.y = angle;
       key.parent = platterGroup;
       key.isPickable = true;
 
       // Per-keycap colored material — color from the shared palette
       const kc = KEYCAP_COLORS[i];
-      const mat = new BABYLON.PBRMaterial(`decorKeyMat${i}`, scene);
-      mat.albedoColor = new BABYLON.Color3(kc.color3.r * 0.3 + 0.1, kc.color3.g * 0.3 + 0.1, kc.color3.b * 0.3 + 0.1);
+      const mat = new PBRMaterial(`decorKeyMat${i}`, scene);
+      mat.albedoColor = new Color3(kc.color3.r * 0.3 + 0.1, kc.color3.g * 0.3 + 0.1, kc.color3.b * 0.3 + 0.1);
       mat.metallic = 0.85;
       mat.roughness = 0.3;
       mat.emissiveColor = kc.color3.scale(0.4);
@@ -195,11 +201,7 @@ export default function Platter() {
       keycapMaterials.push(mat);
 
       // Invisible touch target (1.8x size) for mobile — easier to hit
-      const touchTarget = BABYLON.MeshBuilder.CreateBox(
-        `touchTarget${i}`,
-        { width: 0.22, height: 0.14, depth: 0.22 },
-        scene,
-      );
+      const touchTarget = MeshBuilder.CreateBox(`touchTarget${i}`, { width: 0.22, height: 0.14, depth: 0.22 }, scene);
       touchTarget.position = key.position.clone();
       touchTarget.rotation.y = angle;
       touchTarget.parent = platterGroup;
@@ -208,15 +210,15 @@ export default function Platter() {
 
       // Register interactions on the touch target (not the visible key)
       key.isPickable = false;
-      touchTarget.actionManager = new BABYLON.ActionManager(scene);
+      touchTarget.actionManager = new ActionManager(scene);
       const keycapIndex = i;
       touchTarget.actionManager.registerAction(
-        new BABYLON.ExecuteCodeAction(BABYLON.ActionManager.OnPickDownTrigger, () => {
+        new ExecuteCodeAction(ActionManager.OnPickDownTrigger, () => {
           useInputStore.getState().pressKeycap(keycapIndex);
         }),
       );
       touchTarget.actionManager.registerAction(
-        new BABYLON.ExecuteCodeAction(BABYLON.ActionManager.OnPickUpTrigger, () => {
+        new ExecuteCodeAction(ActionManager.OnPickUpTrigger, () => {
           useInputStore.getState().releaseKeycap(keycapIndex);
         }),
       );
@@ -226,8 +228,8 @@ export default function Platter() {
     keycapMeshes.current = decorKeys;
 
     // Recess glow light
-    const recessLight = new BABYLON.PointLight('recessGlow', BABYLON.Vector3.Zero(), scene);
-    recessLight.diffuse = new BABYLON.Color3(0.2, 0.8, 1.0);
+    const recessLight = new PointLight('recessGlow', Vector3.Zero(), scene);
+    recessLight.diffuse = new Color3(0.2, 0.8, 1.0);
     recessLight.intensity = 0;
     recessLight.parent = platterGroup;
     recessLightRef.current = recessLight;
@@ -264,18 +266,18 @@ export default function Platter() {
       if (recessLightRef.current) {
         recessLightRef.current.intensity = 0.2 + cur * 2.5 + Math.sin(t * 3) * 0.3 * cur;
         // Color shifts from blue to red with tension
-        recessLightRef.current.diffuse = new BABYLON.Color3(0.2 + cur * 0.8, 0.8 - cur * 0.5, 1.0 - cur * 0.7);
+        recessLightRef.current.diffuse = new Color3(0.2 + cur * 0.8, 0.8 - cur * 0.5, 1.0 - cur * 0.7);
       }
 
       // Decorative key emissive pulsing — each key keeps its unique hue
       // but intensity ramps with tension, and all shift toward red at high tension
       keycapMeshes.current.forEach((key, i) => {
-        const mat = key.material as BABYLON.PBRMaterial;
+        const mat = key.material as PBRMaterial;
         if (mat) {
           const kc = KEYCAP_COLORS[i];
           const intensity = 0.4 + cur * 0.6;
           // Blend toward red as tension increases
-          mat.emissiveColor = new BABYLON.Color3(
+          mat.emissiveColor = new Color3(
             lerp(kc.color3.r * intensity, 0.9, cur * 0.4),
             lerp(kc.color3.g * intensity, 0.15, cur * 0.4),
             lerp(kc.color3.b * intensity, 0.08, cur * 0.4),
@@ -296,13 +298,13 @@ function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t;
 }
 
-function openGarageDoor(top: BABYLON.Mesh | null, bottom: BABYLON.Mesh | null, scene?: BABYLON.Scene) {
+function openGarageDoor(top: Mesh | null, bottom: Mesh | null, scene?: Scene) {
   if (!top || !bottom) return;
 
   const tl = gsap.timeline();
 
   tl.to([top.position, bottom.position], {
-    y: (_i: number, target: BABYLON.Vector3) => (target === top.position ? 0.12 : -0.12),
+    y: (_i: number, target: Vector3) => (target === top.position ? 0.12 : -0.12),
     duration: 1.95,
     ease: 'heavyMechanical',
     stagger: 0.22,
@@ -311,7 +313,7 @@ function openGarageDoor(top: BABYLON.Mesh | null, bottom: BABYLON.Mesh | null, s
   tl.to(
     [top.rotation, bottom.rotation],
     {
-      x: (_i: number, target: BABYLON.Vector3) => (target === top.rotation ? -0.095 : 0.095),
+      x: (_i: number, target: Vector3) => (target === top.rotation ? -0.095 : 0.095),
       duration: 1.45,
       ease: 'gearWobble',
       yoyo: true,
@@ -324,7 +326,7 @@ function openGarageDoor(top: BABYLON.Mesh | null, bottom: BABYLON.Mesh | null, s
   // Metallic dust burst on door open — mechanical weight feel
   if (scene) {
     const emitPos = top.absolutePosition.clone();
-    const dustTex = new BABYLON.DynamicTexture('dustTex', 32, scene, false);
+    const dustTex = new DynamicTexture('dustTex', 32, scene, false);
     const ctx = dustTex.getContext();
     ctx.fillStyle = '#ffffff';
     ctx.beginPath();
@@ -332,20 +334,20 @@ function openGarageDoor(top: BABYLON.Mesh | null, bottom: BABYLON.Mesh | null, s
     ctx.fill();
     dustTex.update();
 
-    const dust = new BABYLON.ParticleSystem('garageDust', 200, scene);
+    const dust = new ParticleSystem('garageDust', 200, scene);
     dust.particleTexture = dustTex;
     dust.emitter = emitPos;
     dust.minSize = 0.005;
     dust.maxSize = 0.025;
-    dust.color1 = new BABYLON.Color4(0.6, 0.5, 0.3, 0.9);
-    dust.color2 = new BABYLON.Color4(0.4, 0.35, 0.2, 0.5);
+    dust.color1 = new Color4(0.6, 0.5, 0.3, 0.9);
+    dust.color2 = new Color4(0.4, 0.35, 0.2, 0.5);
     dust.emitRate = 300;
     dust.minLifeTime = 0.5;
     dust.maxLifeTime = 1.8;
-    dust.direction1 = new BABYLON.Vector3(-0.5, 1, -0.5);
-    dust.direction2 = new BABYLON.Vector3(0.5, 3, 0.5);
-    dust.gravity = new BABYLON.Vector3(0, -4, 0);
-    dust.createPointEmitter(new BABYLON.Vector3(-0.05, 0, -0.05), new BABYLON.Vector3(0.05, 0, 0.05));
+    dust.direction1 = new Vector3(-0.5, 1, -0.5);
+    dust.direction2 = new Vector3(0.5, 3, 0.5);
+    dust.gravity = new Vector3(0, -4, 0);
+    dust.createPointEmitter(new Vector3(-0.05, 0, -0.05), new Vector3(0.05, 0, 0.05));
     dust.start();
     dust.targetStopDuration = 1.5;
     // Auto-dispose after completion

--- a/src/components/post-process-corruption.tsx
+++ b/src/components/post-process-corruption.tsx
@@ -1,4 +1,4 @@
-import * as BABYLON from '@babylonjs/core';
+import { Effect, PostProcess } from '@babylonjs/core';
 import { useEffect, useRef } from 'react';
 import { useScene } from 'reactylon';
 import { useLevelStore } from '@/store/level-store';
@@ -9,13 +9,13 @@ interface PostProcessCorruptionProps {
 
 export default function PostProcessCorruption({ reducedMotion }: PostProcessCorruptionProps) {
   const scene = useScene();
-  const effectRef = useRef<BABYLON.PostProcess | null>(null);
+  const effectRef = useRef<PostProcess | null>(null);
 
   useEffect(() => {
-    if (!scene || !scene.activeCamera) return;
+    if (!scene?.activeCamera) return;
 
     // Custom post-process for chromatic aberration + noise + vignette
-    BABYLON.Effect.ShadersStore['corruptionFragmentShader'] = `
+    Effect.ShadersStore['corruptionFragmentShader'] = `
       precision highp float;
       varying vec2 vUV;
       uniform sampler2D textureSampler;
@@ -48,7 +48,7 @@ export default function PostProcessCorruption({ reducedMotion }: PostProcessCorr
       }
     `;
 
-    const postProcess = new BABYLON.PostProcess(
+    const postProcess = new PostProcess(
       'corruptionEffect',
       'corruption',
       ['u_tension', 'u_time'],

--- a/src/components/sps-enemies.tsx
+++ b/src/components/sps-enemies.tsx
@@ -1,4 +1,4 @@
-import * as BABYLON from '@babylonjs/core';
+import { Color3, MeshBuilder, SolidParticleSystem, StandardMaterial } from '@babylonjs/core';
 import { useEffect, useRef } from 'react';
 import { useScene } from 'reactylon';
 import { useLevelStore } from '@/store/level-store';
@@ -13,19 +13,19 @@ import { useLevelStore } from '@/store/level-store';
  */
 export default function SPSEnemies() {
   const scene = useScene();
-  const spsRef = useRef<BABYLON.SolidParticleSystem | null>(null);
+  const spsRef = useRef<SolidParticleSystem | null>(null);
 
   useEffect(() => {
     if (!scene) return;
 
-    const SPS = new BABYLON.SolidParticleSystem('enemiesSPS', scene, { updatable: true });
-    const model = BABYLON.MeshBuilder.CreateBox('spsModel', { size: 0.35 }, scene);
+    const SPS = new SolidParticleSystem('enemiesSPS', scene, { updatable: true });
+    const model = MeshBuilder.CreateBox('spsModel', { size: 0.35 }, scene);
     SPS.addShape(model, 120);
     model.dispose();
 
     const mesh = SPS.buildMesh();
-    const mat = new BABYLON.StandardMaterial('spsMat', scene);
-    mat.emissiveColor = new BABYLON.Color3(0.2, 0.8, 1.0);
+    const mat = new StandardMaterial('spsMat', scene);
+    mat.emissiveColor = new Color3(0.2, 0.8, 1.0);
     mat.alpha = 0.7;
     mesh.material = mat;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
+import { WorldProvider } from 'koota/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import GameBoard from '@/components/gameboard';
+import { world } from '@/sim/world';
 import './styles.css';
 
 const container = document.getElementById('root');
@@ -8,6 +10,8 @@ if (!container) throw new Error('#root element not found in index.html');
 
 createRoot(container).render(
   <StrictMode>
-    <GameBoard />
+    <WorldProvider world={world}>
+      <GameBoard />
+    </WorldProvider>
   </StrictMode>,
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,15 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { createLogger, defineConfig } from 'vite';
 
 /**
  * Vite config for Cognitive Dissonance.
  *
- * Uses @vitejs/plugin-react with Babel — we need `babel-plugin-reactylon`
+ * Uses @vitejs/plugin-react v4 with Babel — we need `babel-plugin-reactylon`
  * to register Babylon.js classes for lowercase JSX tags (<hemisphericLight>,
- * <arcRotateCamera>, etc.). The plugin wraps esbuild's SWC pipeline.
+ * <arcRotateCamera>, etc.). plugin-react v6 dropped the babel.plugins option
+ * (now SWC-only), so we stay on v4 until babel-plugin-reactylon ships an
+ * SWC-compatible variant.
  *
  * GitHub Pages deploy: set `GITHUB_PAGES=true` so `base` becomes
  * `/cognitive-dissonance/`. Default build serves from root.
@@ -15,8 +17,28 @@ import { defineConfig } from 'vite';
 const isGitHubPages = process.env.GITHUB_PAGES === 'true';
 const repoName = 'cognitive-dissonance';
 
+// plugin-react v4 sets esbuild.{jsx,jsxImportSource} and
+// optimizeDeps.rollupOptions.jsx via the older API; Vite 8 / rolldown wants
+// `oxc.*` and `rolldownOptions.*` instead. The behavior is identical (both
+// resolve to the same JSX transform), but Vite logs a deprecation warning
+// for each one. Filter them out so logs stay readable.
+const silentLogger = createLogger();
+const origWarn = silentLogger.warn.bind(silentLogger);
+silentLogger.warn = (msg, ...rest) => {
+  if (
+    typeof msg === 'string' &&
+    (msg.includes('`esbuild` option was specified by "vite:react-babel"') ||
+      msg.includes('optimizeDeps.rollupOptions') ||
+      msg.includes('Both esbuild and oxc options were set'))
+  ) {
+    return;
+  }
+  origWarn(msg, ...rest);
+};
+
 export default defineConfig({
   base: isGitHubPages ? `/${repoName}/` : '/',
+  customLogger: silentLogger,
   plugins: [
     // @vitejs/plugin-react v4 uses Babel and exposes babel.plugins, which is
     // what babel-plugin-reactylon needs to auto-register Babylon.js classes
@@ -58,10 +80,12 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       '@babylonjs/core',
+      // Reactylon imports @babylonjs/gui internally for its 3D GUI manager;
+      // even if we don't use GUI features in our JSX, the package needs to
+      // resolve at module-init time.
       '@babylonjs/gui',
-      '@babylonjs/loaders',
       'gsap',
-      'miniplex',
+      'koota',
       'react',
       'react-dom',
       'reactylon',
@@ -69,7 +93,6 @@ export default defineConfig({
       'seedrandom',
       'tone',
       'yuka',
-      'zustand',
     ],
   },
 });

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,7 +1,24 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
+import { createLogger } from 'vite';
 import { defineConfig } from 'vitest/config';
+
+// Suppress plugin-react-v4-vs-rolldown deprecation warnings (same fix as
+// vite.config.ts — they're cosmetic, behavior is identical).
+const silentLogger = createLogger();
+const origWarn = silentLogger.warn.bind(silentLogger);
+silentLogger.warn = (msg, ...rest) => {
+  if (
+    typeof msg === 'string' &&
+    (msg.includes('`esbuild` option was specified by "vite:react-babel"') ||
+      msg.includes('optimizeDeps.rollupOptions') ||
+      msg.includes('Both esbuild and oxc options were set'))
+  ) {
+    return;
+  }
+  origWarn(msg, ...rest);
+};
 
 /**
  * Vitest browser mode — runs component tests in a real Chromium browser via
@@ -11,6 +28,7 @@ import { defineConfig } from 'vitest/config';
  * render to canvas (isolation tests that complement the full-app E2E suite).
  */
 export default defineConfig({
+  customLogger: silentLogger,
   plugins: [
     // Run babel-plugin-reactylon so lowercase JSX tags (<hemisphericLight>) get
     // auto-registered to Babylon classes in the test bundle, same as the app.
@@ -84,7 +102,6 @@ export default defineConfig({
       '@babylonjs/core/Misc/environmentTextureTools',
       '@babylonjs/core/Misc/rgbdTextureTools',
       '@babylonjs/gui',
-      '@babylonjs/loaders',
       'gsap',
       'gsap/CustomEase',
       'koota',


### PR DESCRIPTION
## Summary

Three P1 polish items from the post-launch task list. All non-breaking, all tested locally.

## Changes

### Vite deprecation warnings (#38)
- `@vitejs/plugin-react` v4 sets the older `esbuild.{jsx}` and `optimizeDeps.rollupOptions.jsx` keys; Vite 8/rolldown wants `oxc.*` / `rolldownOptions.*`. Behavior is identical, but Vite logs deprecation warnings each build. Added a `customLogger` that filters just those three specific warnings — keeps logs readable.
- Same fix in `vitest.browser.config.ts`.
- Cleaned up stale `miniplex` and `zustand` from `optimizeDeps.include` (leftover from v3 ECS migration).

### Koota hooks native usage (#37)
- `src/main.tsx` wraps the app in `<WorldProvider world={world}>`.
- `mount-scene` test helper: same wrap so isolated component tests can read traits.
- `DiegeticGUI`: reads coherence directly via `useTrait(world, Level)` — no more prop drilling from `GameBoard` → `GameScene` → `SceneContent` → `DiegeticGUI`.
- `GameBoard`: same migration for tension reads.
- Browser tests for DiegeticGUI: set `Level` trait via `useLevelStore.setState({ coherence })` before mount.

The Zustand-shim API is preserved for incremental migration; this PR converts only the two consumers where prop-drilling was loudest.

### Bundle size: lazy-load Babylon (#39)
- Wrapped `<GameScene />` in `React.lazy()` + `<Suspense fallback={null}>`.
- Initial JS chunk dropped from **252 KB → 12 KB** (gzip 82 KB → 4.5 KB).
- The "INITIALIZING CORE" overlay covers the GameScene chunk fetch, so no visible regression.
- Babylon chunk stays at 6.7 MB / 1.5 MB gz — `@babylonjs/core` declares `sideEffects: ["**/*"]` upstream, so rolldown can't tree-shake even with named imports.
- Bonus: converted all 9 component files from `import * as BABYLON` to named imports. Doesn't shrink the bundle today (per above) but is prerequisite for future tree-shaking and reads cleaner.

### Dependency bumps to latest
- `@babylonjs/core` 8.56 → 9.2.1
- `@babylonjs/gui` 8.56 → 9.2.1 (re-added — Reactylon imports it internally for its 3D GUI manager)
- `@babylonjs/havok` latest
- `@biomejs/biome` 2.4.5 → 2.4.11
- `jsdom` 28 → 29
- `typescript` 5.9.3 → 6.0.2
- Removed unused `@babylonjs/loaders`.

## Test plan

- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 60 unit tests pass
- [x] `pnpm test:browser` — 48 browser component tests pass on cold cache
- [ ] CI verification (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)