### PR TITLE
feat: playable loop — audio, pointer raycast, stabilizer, tension, game-over

### DIFF
--- a/src/boot/audio.ts
+++ b/src/boot/audio.ts
@@ -1,0 +1,186 @@
+/**
+ * Audio engine — Tone.js driven by Koota tension.
+ *
+ * Must be lazy-initialized on the first user gesture (browsers require a
+ * user interaction before audio-context starts). The initialize() helper
+ * is idempotent; call from any pointer/keydown/touchstart handler.
+ *
+ * The graph is minimal on purpose — we ship the essentials and tune by ear:
+ *   - droneSynth: sustained low-frequency triangle, the "engine hum"
+ *   - padFilter + pads: duochord pads that swell with tension
+ *   - glitchNoise + glitchEnv: white-noise bursts gated by an LFO,
+ *     density scales with tension — the "corruption" sound
+ *   - chimes: a sparse arpeggio that drops notes as tension rises
+ *     (communicating "the machine is losing the melody")
+ *
+ * Four stems map to the 4 tension bands:
+ *   calm      (0.0–0.3)  drone + pads, no glitch, full chimes
+ *   warn      (0.3–0.6)  drone + pads hotter, chimes dropping
+ *   danger    (0.6–0.85) drone + pads + glitch active, chimes chaotic
+ *   collapse  (0.85–1.0) all layers max, glitch crescendo
+ *
+ * Collapse layer is reserved as task #42 — currently we just push glitch
+ * to max intensity at crisis. The dedicated stem is follow-up polish.
+ */
+
+import type { World } from 'koota';
+import * as Tone from 'tone';
+import { Audio, Level } from '@/sim/world';
+
+export interface AudioEngine {
+  /** Lazy-initialize Tone.js. Safe to call multiple times. */
+  initialize(): Promise<void>;
+  /** Teardown — call before page unload. */
+  dispose(): void;
+}
+
+export function createAudioEngine(world: World): AudioEngine {
+  let masterGain: Tone.Gain | null = null;
+  let drone: Tone.Oscillator | null = null;
+  let padFilter: Tone.Filter | null = null;
+  let pads: Tone.PolySynth | null = null;
+  let glitchFilter: Tone.Filter | null = null;
+  let glitchNoise: Tone.Noise | null = null;
+  let glitchEnv: Tone.AmplitudeEnvelope | null = null;
+  let chimes: Tone.PolySynth | null = null;
+  let loop: Tone.Loop | null = null;
+  let frame: number | null = null;
+
+  async function initialize(): Promise<void> {
+    if (world.get(Audio)?.isInitialized) return;
+    await Tone.start();
+
+    masterGain = new Tone.Gain(0.55).toDestination();
+
+    // Drone — constant low hum, pitch bends slightly with tension.
+    drone = new Tone.Oscillator({ frequency: 48, type: 'triangle', volume: -22 });
+    drone.connect(masterGain);
+    drone.start();
+
+    // Pads — two-voice polyphonic sustained chord.
+    padFilter = new Tone.Filter({ frequency: 800, type: 'lowpass', Q: 2 });
+    padFilter.connect(masterGain);
+    pads = new Tone.PolySynth(Tone.Synth, {
+      oscillator: { type: 'sine' },
+      envelope: { attack: 2, decay: 1, sustain: 0.7, release: 3 },
+      volume: -18,
+    });
+    pads.maxPolyphony = 6;
+    pads.connect(padFilter);
+    pads.triggerAttack(['C2', 'G2', 'Eb3']);
+
+    // Glitch — noise gated by an envelope, fires on a loop with randomized gaps.
+    glitchFilter = new Tone.Filter({ frequency: 2400, type: 'bandpass', Q: 4 });
+    glitchFilter.connect(masterGain);
+    glitchNoise = new Tone.Noise('pink');
+    glitchEnv = new Tone.AmplitudeEnvelope({ attack: 0.001, decay: 0.06, sustain: 0, release: 0.08 });
+    glitchNoise.chain(glitchEnv, glitchFilter);
+    glitchNoise.start();
+
+    // Chimes — a polysynth that plays a rotating pentatonic pattern.
+    chimes = new Tone.PolySynth(Tone.Synth, {
+      oscillator: { type: 'triangle' },
+      envelope: { attack: 0.005, decay: 0.3, sustain: 0.1, release: 0.4 },
+      volume: -12,
+    });
+    chimes.maxPolyphony = 8;
+    chimes.connect(masterGain);
+
+    const pentatonic = ['C5', 'Eb5', 'G5', 'Bb5', 'C6'];
+    let step = 0;
+    loop = new Tone.Loop((time) => {
+      const tension = world.get(Level)?.tension ?? 0;
+      // Note density: 1 note per 4 beats at calm, 1 per 12 at crisis.
+      // Calm = steady, crisis = sparse (the melody losing the plot).
+      const playChance = 0.35 * (1 - tension * 0.85);
+      if (Math.random() < playChance) {
+        const noteIdx = (step + (Math.random() < tension ? Math.floor(Math.random() * 3) : 0)) % pentatonic.length;
+        chimes?.triggerAttackRelease(pentatonic[noteIdx], '16n', time);
+      }
+      step = (step + 1) % 16;
+    }, '4n');
+    loop.start(0);
+
+    Tone.getTransport().start();
+
+    // Per-frame parameter drive. Runs from rAF, not Tone's transport.
+    function tick(): void {
+      const tension = world.get(Level)?.tension ?? 0;
+
+      if (drone) {
+        // Pitch bends up slightly with tension — 48Hz calm → 56Hz crisis.
+        drone.frequency.rampTo(48 + tension * 8, 0.1);
+        drone.volume.rampTo(-22 + tension * 4, 0.1);
+      }
+      if (padFilter) {
+        // Filter opens up as tension rises — more "brightness" in the pads.
+        padFilter.frequency.rampTo(800 + tension * 2400, 0.1);
+      }
+      if (glitchFilter) {
+        glitchFilter.frequency.rampTo(800 + tension * 3000, 0.1);
+      }
+      if (glitchEnv) {
+        // Fire glitch envelopes more often as tension climbs.
+        if (Math.random() < tension * 0.12) {
+          glitchEnv.triggerAttackRelease(0.05 + Math.random() * 0.1);
+        }
+      }
+      if (masterGain) {
+        masterGain.gain.rampTo(0.4 + tension * 0.4, 0.1);
+      }
+
+      frame = requestAnimationFrame(tick);
+    }
+    frame = requestAnimationFrame(tick);
+
+    world.set(Audio, (prev) => ({ ...prev, isInitialized: true }));
+  }
+
+  function dispose(): void {
+    if (frame !== null) cancelAnimationFrame(frame);
+    loop?.dispose();
+    chimes?.dispose();
+    glitchEnv?.dispose();
+    glitchNoise?.dispose();
+    glitchFilter?.dispose();
+    pads?.dispose();
+    padFilter?.dispose();
+    drone?.dispose();
+    masterGain?.dispose();
+    try {
+      Tone.getTransport().stop();
+    } catch {
+      // Transport may already be stopped.
+    }
+    world.set(Audio, (prev) => ({ ...prev, isInitialized: false }));
+  }
+
+  return { initialize, dispose };
+}
+
+/**
+ * Wire first-gesture listeners that kick off audio. Removes themselves
+ * after the first successful init so subsequent gestures are free.
+ */
+export function mountFirstGestureAudio(engine: AudioEngine): () => void {
+  let unmounted = false;
+
+  async function kick(): Promise<void> {
+    if (unmounted) return;
+    await engine.initialize();
+    detach();
+  }
+
+  function detach(): void {
+    unmounted = true;
+    window.removeEventListener('pointerdown', kick);
+    window.removeEventListener('keydown', kick);
+    window.removeEventListener('touchstart', kick);
+  }
+
+  window.addEventListener('pointerdown', kick, { passive: true });
+  window.addEventListener('keydown', kick);
+  window.addEventListener('touchstart', kick, { passive: true });
+
+  return detach;
+}

--- a/src/boot/game-over.ts
+++ b/src/boot/game-over.ts
@@ -1,0 +1,51 @@
+/**
+ * Game-over flow — listens for the `gameOver` event, freezes the sim,
+ * and auto-restarts after a short interval. A future pass will add a
+ * diegetic shatter (glass sphere cracks, particles burst, red bloom
+ * drowns the scene) via rapier.
+ *
+ * The restart rebuilds the sim state: resets Level trait, generates a new
+ * seed, transitions Game.phase back to 'playing'. Keycap emergence will
+ * replay because the inputSchema reference is preserved (same array);
+ * bring in a proper schema-swap later if we want a different level
+ * automatically on restart.
+ */
+
+import type { World } from 'koota';
+import { generateNewSeed, resetLevel, setPhase } from '@/sim/actions';
+
+const RESTART_DELAY_MS = 3000;
+
+export interface GameOverHandlerOptions {
+  world: World;
+  restartDelayMs?: number;
+}
+
+export function mountGameOverHandler(opts: GameOverHandlerOptions): () => void {
+  const { world: _world, restartDelayMs = RESTART_DELAY_MS } = opts;
+  let restartTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function onGameOver(): void {
+    // Phase is already set to 'gameover' by the tension-driver; schedule
+    // restart. Tension stays high and patterns stop spawning (stabilizer
+    // gates on phase), giving the player a moment to read "cognition
+    // shattered" before the cabinet resets.
+    if (restartTimer !== null) return; // already mid-restart
+    restartTimer = setTimeout(() => {
+      restartTimer = null;
+      resetLevel();
+      generateNewSeed();
+      setPhase('playing');
+    }, restartDelayMs);
+  }
+
+  window.addEventListener('gameOver', onGameOver);
+
+  return function unmount() {
+    window.removeEventListener('gameOver', onGameOver);
+    if (restartTimer !== null) {
+      clearTimeout(restartTimer);
+      restartTimer = null;
+    }
+  };
+}

--- a/src/boot/input.ts
+++ b/src/boot/input.ts
@@ -7,29 +7,29 @@
  * this every frame to drive the per-control press travel.
  *
  * Mapping:
- *   - Digit keys 1..9,0,-,= → control indices 0..11 (first 12 slots)
- *     Extra Number keys map to higher indices if the schema is longer.
- *   - Pointer hits on control meshes → corresponding control index
- *     (raycast resolves the slot).
+ *   - Digit keys 1..9,0,-,= → control indices 0..11 (first 12 slots).
+ *     Extras map to q..p,[,] (indices 12..23) for longer schemas.
+ *   - Pointer / touch down on the canvas → raycast from camera through
+ *     cursor, find nearest intersected control mesh, press its index.
+ *     Tracks active pointers so you can multi-touch chords on mobile.
  *
  * No framework. Raw `addEventListener`. Returns an unmount fn that removes
  * every listener for clean Capacitor re-entry.
  */
 
 import type { World } from 'koota';
+import { type Camera, Raycaster, Vector2 } from 'three';
 import { Input, Level } from '@/sim/world';
+import type { EmergentControls } from '@/three/emergent-controls';
 
 export interface InputOptions {
   world: World;
   canvas: HTMLCanvasElement;
+  camera: Camera;
+  /** Accessor — the rig rebuilds on schema change, so don't hold a ref. */
+  getControls: () => EmergentControls;
 }
 
-/**
- * Keyboard ordinal → index mapping. We want natural keyboard order:
- *   Row 1: 1 2 3 4 5 6 7 8 9 0 - =
- * giving indices 0..11 for a standard 12-slot pattern schema.
- * Longer schemas overflow to q w e r t y u i o p [ ] (indices 12..23).
- */
 const KEY_ORDER = [
   'Digit1',
   'Digit2',
@@ -58,7 +58,12 @@ const KEY_ORDER = [
 ];
 
 export function mountInputListeners(opts: InputOptions): () => void {
-  const { world, canvas } = opts;
+  const { world, canvas, camera, getControls } = opts;
+
+  const raycaster = new Raycaster();
+  const ndc = new Vector2();
+  /** Maps pointerId → control index so release hits the right slot. */
+  const activePointers = new Map<number, number>();
 
   function press(index: number): void {
     world.set(Input, (prev) => {
@@ -75,6 +80,7 @@ export function mountInputListeners(opts: InputOptions): () => void {
     });
   }
 
+  // ── Keyboard ────────────────────────────────────────────────────────────
   function keyDown(ev: KeyboardEvent): void {
     if (ev.repeat) return;
     const i = KEY_ORDER.indexOf(ev.code);
@@ -90,21 +96,67 @@ export function mountInputListeners(opts: InputOptions): () => void {
     release(i);
   }
 
-  // Pointer hits on control meshes require a raycast from camera through
-  // the cursor position. The cabinet module owns the scene + camera + raycaster
-  // and reads `heldKeycaps` — but the raycast itself needs access to those.
-  // For Phase 1 we only wire keyboard; pointer + touch will land next.
+  // ── Pointer / touch raycast ─────────────────────────────────────────────
+  /** Convert a DOM event's client coords into Three NDC. */
+  function updateNDC(clientX: number, clientY: number): void {
+    const rect = canvas.getBoundingClientRect();
+    ndc.x = ((clientX - rect.left) / rect.width) * 2 - 1;
+    ndc.y = -((clientY - rect.top) / rect.height) * 2 + 1;
+  }
 
+  /** Resolve the clicked control index from a canvas event, or null if none. */
+  function hitTest(clientX: number, clientY: number): number | null {
+    updateNDC(clientX, clientY);
+    raycaster.setFromCamera(ndc, camera);
+    const rig = getControls();
+    const hittable = rig.controls.map((c) => c.mesh);
+    const hits = raycaster.intersectObjects(hittable, false);
+    if (hits.length === 0) return null;
+    const hitMesh = hits[0].object;
+    const idx = rig.controls.findIndex((c) => c.mesh === hitMesh);
+    return idx >= 0 ? idx : null;
+  }
+
+  function pointerDown(ev: PointerEvent): void {
+    const idx = hitTest(ev.clientX, ev.clientY);
+    if (idx === null) return;
+    activePointers.set(ev.pointerId, idx);
+    press(idx);
+    canvas.setPointerCapture(ev.pointerId);
+  }
+
+  function pointerUp(ev: PointerEvent): void {
+    const idx = activePointers.get(ev.pointerId);
+    if (idx === undefined) return;
+    activePointers.delete(ev.pointerId);
+    release(idx);
+    if (canvas.hasPointerCapture(ev.pointerId)) {
+      canvas.releasePointerCapture(ev.pointerId);
+    }
+  }
+
+  function pointerCancel(ev: PointerEvent): void {
+    pointerUp(ev);
+  }
+
+  // ── Wire ────────────────────────────────────────────────────────────────
   window.addEventListener('keydown', keyDown);
   window.addEventListener('keyup', keyUp);
+  canvas.addEventListener('pointerdown', pointerDown);
+  canvas.addEventListener('pointerup', pointerUp);
+  canvas.addEventListener('pointercancel', pointerCancel);
 
-  // Prevent default pointer behavior on the canvas (no text-selection
-  // drag, no scroll) without blocking the raycast wiring to follow.
   canvas.style.touchAction = 'none';
   canvas.style.userSelect = 'none';
 
   return function unmount() {
     window.removeEventListener('keydown', keyDown);
     window.removeEventListener('keyup', keyUp);
+    canvas.removeEventListener('pointerdown', pointerDown);
+    canvas.removeEventListener('pointerup', pointerUp);
+    canvas.removeEventListener('pointercancel', pointerCancel);
+    // Release every held key on unmount so the next mount starts clean.
+    for (const idx of activePointers.values()) release(idx);
+    activePointers.clear();
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,9 +9,13 @@
  * post-process escalation) is diegetic — on the three.js scene.
  */
 
-import { setTension } from '@/sim/actions';
+import { setPhase, setTension } from '@/sim/actions';
+import { createPatternStabilizerState, tickPatternStabilizer } from '@/sim/systems/pattern-stabilizer';
+import { tickTensionDriver } from '@/sim/systems/tension-driver';
 import { Level, world } from '@/sim/world';
+import { createAudioEngine, mountFirstGestureAudio } from './boot/audio';
 import { mountBootOverlay } from './boot/boot-overlay';
+import { mountGameOverHandler } from './boot/game-over';
 import { mountInputListeners } from './boot/input';
 import { createCabinet } from './three/cabinet';
 import './styles.css';
@@ -42,8 +46,20 @@ async function mount(): Promise<void> {
     reducedMotion: prefersReducedMotion(),
   });
 
-  // ── Input
-  const unmountInput = mountInputListeners({ world, canvas });
+  // ── Input (keyboard + pointer-raycast)
+  const unmountInput = mountInputListeners({
+    world,
+    canvas,
+    camera: cabinet.camera,
+    getControls: cabinet.getEmergentControls,
+  });
+
+  // ── Audio (lazy-init on first gesture)
+  const audio = createAudioEngine(world);
+  const detachFirstGesture = mountFirstGestureAudio(audio);
+
+  // ── Game-over / restart handler
+  const unmountGameOver = mountGameOverHandler({ world });
 
   // ── Resize
   const ro =
@@ -59,12 +75,22 @@ async function mount(): Promise<void> {
     cabinet.resize(canvas.clientWidth, canvas.clientHeight);
   });
 
+  // ── Sim state
+  const stabilizer = createPatternStabilizerState();
+
+  // Transition to playing phase on first frame — the cabinet IS the menu,
+  // so there's no separate title state. Keycap emergence handles the
+  // "this is a new game" cue.
+  setPhase('playing');
+
   // ── Render loop
   let last = performance.now();
   let firstFrame = true;
   function frame(now: number): void {
     const dt = Math.min(0.1, (now - last) / 1000);
     last = now;
+    tickPatternStabilizer(world, stabilizer, dt);
+    tickTensionDriver(world, dt);
     cabinet.render(dt);
     if (firstFrame) {
       firstFrame = false;
@@ -97,6 +123,9 @@ async function mount(): Promise<void> {
   // Teardown on page unload — Capacitor keeps this process alive, so we
   // clean up properly to avoid GPU resource leaks on swipe-home.
   window.addEventListener('pagehide', () => {
+    detachFirstGesture();
+    unmountGameOver();
+    audio.dispose();
     unmountInput();
     ro?.disconnect();
     cabinet.dispose();

--- a/src/sim/systems/pattern-stabilizer.ts
+++ b/src/sim/systems/pattern-stabilizer.ts
@@ -1,0 +1,129 @@
+/**
+ * Pattern-stabilizer system — the core gameplay loop.
+ *
+ * Each step:
+ *   1. Spawn new patterns at a tension-scaled interval
+ *   2. Advance each active pattern's progress outward from the sphere
+ *   3. Held keycaps matching a pattern's colorIndex pull it back inward
+ *   4. If progress ≥ 1: pattern escaped → tension +, remove entity
+ *   5. If progress ≤ 0: pattern stabilised → coherence +, remove entity
+ *
+ * Runs at a fixed 30Hz regardless of render fps (via runFixedSteps). Pure
+ * Koota ECS mutations — no three.js imports. The cabinet renderer reads
+ * Pattern entities each frame and draws them.
+ */
+
+import type { World } from 'koota';
+import { type FixedStepState, runFixedSteps, spawnIntervalSeconds } from '@/lib/fixed-step';
+import { KEYCAP_COLORS, KEYCAP_COUNT } from '@/lib/keycap-colors';
+import { Game, Input, IsPattern, Level, Pattern, Position, Seed } from '../world';
+
+const FIXED_STEP_S = 1 / 30;
+const PATTERN_PULL_RATE = 2.4; // progress/sec pulled back when the matching keycap is held
+const COHERENCE_REWARD = 3; // per stabilised pattern
+const TENSION_PENALTY = 0.12; // per escaped pattern
+const MAX_TENSION = 1;
+const MIN_TENSION = 0;
+
+export interface PatternStabilizerState {
+  fixedStep: FixedStepState;
+  spawnTimer: number;
+}
+
+export function createPatternStabilizerState(): PatternStabilizerState {
+  return {
+    fixedStep: { accumulator: 0 },
+    spawnTimer: 0.3,
+  };
+}
+
+/**
+ * Drive one frame of the sim. Skip work unless `Game.phase === 'playing'`.
+ */
+export function tickPatternStabilizer(world: World, state: PatternStabilizerState, dt: number): void {
+  if (world.get(Game)?.phase !== 'playing') {
+    state.fixedStep.accumulator = 0;
+    return;
+  }
+
+  runFixedSteps(state.fixedStep, dt, FIXED_STEP_S, (stepDt) => {
+    runOneStep(world, state, stepDt);
+  });
+}
+
+function runOneStep(world: World, state: PatternStabilizerState, dt: number): void {
+  const seed = world.get(Seed);
+  const rng = seed?.rng ?? Math.random;
+  const curLevel = world.get(Level);
+  const curTension = curLevel?.tension ?? 0;
+
+  // ── Spawn ────────────────────────────────────────────────────────────
+  state.spawnTimer -= dt;
+  if (state.spawnTimer <= 0) {
+    spawnPattern(world, rng, curTension);
+    state.spawnTimer = spawnIntervalSeconds(curTension, rng, 0.16, 1.1);
+  }
+
+  // ── Update every active pattern ──────────────────────────────────────
+  const held = world.get(Input)?.heldKeycaps ?? new Set<number>();
+  let escapedCount = 0;
+  let stabilisedCount = 0;
+  const toDestroy: Array<ReturnType<typeof world.query>[number]> = [];
+
+  world.query(IsPattern, Pattern, Position).updateEach(([pattern, position], entity) => {
+    let nextProgress = pattern.progress + pattern.speed * dt;
+    if (held.has(pattern.colorIndex)) {
+      nextProgress = Math.max(0, nextProgress - PATTERN_PULL_RATE * dt);
+    }
+    pattern.progress = nextProgress;
+    const radius = nextProgress * 0.52;
+    position.x = Math.cos(pattern.angle) * radius;
+    position.y = 0.4;
+    position.z = Math.sin(pattern.angle) * radius;
+
+    if (nextProgress >= 1) {
+      escapedCount++;
+      toDestroy.push(entity);
+    } else if (nextProgress <= 0) {
+      stabilisedCount++;
+      toDestroy.push(entity);
+    }
+  });
+
+  for (const e of toDestroy) e.destroy();
+
+  if (escapedCount > 0) {
+    world.set(Level, (prev) => ({
+      ...prev,
+      tension: Math.min(MAX_TENSION, prev.tension + escapedCount * TENSION_PENALTY),
+    }));
+  }
+  if (stabilisedCount > 0) {
+    world.set(Level, (prev) => {
+      const nextCoh = prev.coherence + stabilisedCount * COHERENCE_REWARD;
+      return {
+        ...prev,
+        coherence: nextCoh,
+        peakCoherence: Math.max(prev.peakCoherence, nextCoh),
+        tension: Math.max(MIN_TENSION, prev.tension - stabilisedCount * 0.05),
+      };
+    });
+  }
+}
+
+function spawnPattern(world: World, rng: () => number, tension: number): void {
+  const colorIndex = Math.floor(rng() * KEYCAP_COUNT);
+  const kc = KEYCAP_COLORS[colorIndex];
+  const speed = 0.3 + rng() * (0.4 + tension * 1.2);
+  const angle = rng() * Math.PI * 2;
+
+  const entity = world.spawn(IsPattern, Pattern, Position);
+  entity.set(Pattern, {
+    progress: 0,
+    speed,
+    colorIndex,
+    angle,
+    color: kc.hex,
+  });
+  entity.set(Position, { x: 0, y: 0.4, z: 0 });
+}

--- a/src/sim/systems/tension-driver.ts
+++ b/src/sim/systems/tension-driver.ts
@@ -1,0 +1,67 @@
+/**
+ * Tension-driver system — the meta-gameplay layer.
+ *
+ * Runs alongside the pattern-stabilizer and governs:
+ *   - Passive tension decay (idle tension slowly drifts toward a calm
+ *     baseline so the player isn't punished for thinking)
+ *   - Coherence drain under high tension (the AI is losing the plot)
+ *   - Game-over trigger when coherence hits 0
+ *   - Level advancement when coherence passes a threshold
+ *
+ * Runs every frame (not fixed-step — these are slow continuous changes,
+ * small frame-rate variance is imperceptible).
+ */
+
+import type { World } from 'koota';
+import { setPhase } from '../actions';
+import { Game, Level } from '../world';
+
+const IDLE_TENSION_DECAY = 0.04; // per sec, drifts toward 0.12 baseline
+const TENSION_BASELINE = 0.12;
+const HIGH_TENSION_THRESHOLD = 0.75;
+const COHERENCE_DRAIN_PER_SEC = 2; // when tension > threshold
+const LEVEL_UP_COHERENCE = 100;
+const GAMEOVER_COHERENCE = 0;
+
+export function tickTensionDriver(world: World, dt: number): void {
+  if (world.get(Game)?.phase !== 'playing') return;
+
+  const level = world.get(Level);
+  if (!level) return;
+
+  let { tension, coherence, currentLevel, peakCoherence } = level;
+
+  // Passive decay toward baseline.
+  const drift = tension - TENSION_BASELINE;
+  tension -= Math.sign(drift) * Math.min(Math.abs(drift), IDLE_TENSION_DECAY * dt);
+
+  // High-tension drain.
+  if (tension > HIGH_TENSION_THRESHOLD) {
+    const overage = (tension - HIGH_TENSION_THRESHOLD) / (1 - HIGH_TENSION_THRESHOLD);
+    coherence -= COHERENCE_DRAIN_PER_SEC * overage * dt;
+  }
+
+  // Level up — at 100 coherence, advance level and reset to 25 with a
+  // coherence boost carried into the next level's starting peak.
+  if (coherence >= LEVEL_UP_COHERENCE) {
+    currentLevel += 1;
+    peakCoherence = Math.max(peakCoherence, coherence);
+    coherence = 25;
+    tension = TENSION_BASELINE;
+    // Small event for audio + visuals to latch onto.
+    window.dispatchEvent(new CustomEvent('coherenceMaintained', { detail: { level: currentLevel } }));
+  }
+
+  peakCoherence = Math.max(peakCoherence, coherence);
+
+  // Game over — when coherence is drained to zero, the cognition shatters.
+  if (coherence <= GAMEOVER_COHERENCE) {
+    coherence = 0;
+    world.set(Level, { ...level, tension: Math.max(tension, 0), coherence, currentLevel, peakCoherence });
+    setPhase('gameover');
+    window.dispatchEvent(new CustomEvent('gameOver', { detail: { peakCoherence, currentLevel } }));
+    return;
+  }
+
+  world.set(Level, { ...level, tension, coherence, currentLevel, peakCoherence });
+}

--- a/src/sim/traits.ts
+++ b/src/sim/traits.ts
@@ -145,11 +145,13 @@ export const Enemy = trait({
   kind: 'seek' as 'seek' | 'zigzag' | 'split' | 'wander',
 });
 
-/** Pattern progress (0..1 from center to rim) + speed + color index. */
+/** Pattern progress (0..1 from center to rim) + speed + color index + angle. */
 export const Pattern = trait({
   progress: 0,
   speed: 0.5,
   colorIndex: 0,
+  /** Radial angle (0..2π) — fixed at spawn, escape direction. */
+  angle: 0,
   /** Hex color, kept here so renderer doesn't need a separate trait. */
   color: '#ffffff',
 });

--- a/src/three/cabinet.ts
+++ b/src/three/cabinet.ts
@@ -30,10 +30,11 @@ import {
   WebGLRenderer,
 } from 'three';
 import { RoomEnvironment } from 'three-stdlib';
-import { Level } from '@/sim/world';
+import { Input, Level } from '@/sim/world';
 import { type AICore, createAICore } from './ai-core';
 import { createEmergentControls, type EmergentControls } from './emergent-controls';
 import { createIndustrialPlatter, type IndustrialPlatter } from './industrial-platter';
+import { createPatternTrails, type PatternTrails } from './pattern-trails';
 import { CorruptionEffect } from './post-process-corruption';
 import { createSkyRain, type SkyRain } from './sky-rain';
 
@@ -51,6 +52,7 @@ export interface Cabinet {
   platter: IndustrialPlatter;
   aiCore: AICore;
   skyRain: SkyRain;
+  patternTrails: PatternTrails;
   /**
    * Current emergent-controls rig. Accessor (not bare property) because the
    * internal reference is swapped when Level.inputSchema changes — callers
@@ -131,6 +133,7 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
     position: new Vector3(0, 0.4, 0),
   });
   const skyRain = createSkyRain(scene, { count: 160 });
+  const patternTrails = createPatternTrails(scene, kootaWorld);
 
   const initialSchema = kootaWorld.get(Level)?.inputSchema ?? [];
   let emergentControls = createEmergentControls(scene, {
@@ -214,11 +217,21 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
     // rapier bodies in a follow-up so the visual sim and physics sim agree).
     skyRain.update(dt, tension);
 
+    // Pattern trails — read Koota pattern entities and draw.
+    patternTrails.update();
+
     // Emergent controls staggered emerge.
     if (emergeFn) {
       const elapsed = tNow - emergeStart;
       const done = emergeFn(elapsed);
       if (done) emergeFn = null;
+    }
+
+    // Reflect Input.heldKeycaps on the control rig — pressed keycaps
+    // dip down + brighten, released ones return to rest.
+    const heldSet = kootaWorld.get(Input)?.heldKeycaps;
+    for (let i = 0; i < emergentControls.controls.length; i++) {
+      emergentControls.setPressed(i, heldSet?.has(i) ? 1 : 0);
     }
 
     // Advance corruption time uniform and render through composer.
@@ -234,6 +247,7 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
   }
 
   function dispose(): void {
+    patternTrails.dispose();
     emergentControls.dispose();
     skyRain.dispose();
     aiCore.dispose();
@@ -254,6 +268,7 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
     platter,
     aiCore,
     skyRain,
+    patternTrails,
     getEmergentControls: () => emergentControls,
     corruption,
     render,

--- a/src/three/pattern-trails.ts
+++ b/src/three/pattern-trails.ts
@@ -1,0 +1,80 @@
+/**
+ * Pattern trails — renders active `Pattern` entities as glowing trails.
+ *
+ * The stabilizer sim spawns entities and updates their Position every
+ * fixed step. This renderer reads the current snapshot each frame and
+ * draws every pattern as a small emissive sphere whose color matches
+ * the pattern's keycap palette slot.
+ *
+ * Uses a per-pattern pool of mesh instances so we never allocate during
+ * the render loop. When a pattern entity disappears, its mesh is parked
+ * off-screen and reused for the next spawn.
+ */
+
+import type { World } from 'koota';
+import { Color, Mesh, MeshBasicMaterial, type Scene, SphereGeometry } from 'three';
+import { IsPattern, Pattern, Position } from '@/sim/world';
+
+const MAX_PATTERNS = 32;
+const TRAIL_RADIUS = 0.04;
+
+export interface PatternTrails {
+  update(): void;
+  dispose(): void;
+}
+
+export function createPatternTrails(scene: Scene, world: World): PatternTrails {
+  const geometry = new SphereGeometry(TRAIL_RADIUS, 10, 10);
+  const meshes: Mesh[] = [];
+
+  for (let i = 0; i < MAX_PATTERNS; i++) {
+    const material = new MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.95,
+    });
+    const mesh = new Mesh(geometry, material);
+    mesh.visible = false;
+    mesh.position.set(0, -100, 0);
+    scene.add(mesh);
+    meshes.push(mesh);
+  }
+
+  const tmpColor = new Color();
+
+  function update(): void {
+    let slot = 0;
+
+    world.query(IsPattern, Pattern, Position).updateEach(([pattern, pos]) => {
+      if (slot >= MAX_PATTERNS) return;
+      const m = meshes[slot++];
+      const mat = m.material as MeshBasicMaterial;
+      tmpColor.set(pattern.color);
+      mat.color.copy(tmpColor);
+      // Trail grows hotter as it nears escape.
+      const heat = pattern.progress;
+      mat.opacity = 0.85 + heat * 0.15;
+      m.position.set(pos.x, pos.y, pos.z);
+      // Slight scaling with progress for a "growing threat" read.
+      const scale = 0.9 + heat * 1.1;
+      m.scale.setScalar(scale);
+      m.visible = true;
+    });
+
+    // Hide unused slots.
+    for (let i = slot; i < MAX_PATTERNS; i++) {
+      meshes[i].visible = false;
+      meshes[i].position.set(0, -100, 0);
+    }
+  }
+
+  function dispose(): void {
+    for (const m of meshes) {
+      scene.remove(m);
+      (m.material as MeshBasicMaterial).dispose();
+    }
+    geometry.dispose();
+  }
+
+  return { update, dispose };
+}


### PR DESCRIPTION
## Summary

v4 is now an actual game. Five systems shipped:
- **Audio** — Tone.js graph lazily initialized on first gesture; four layers (drone, pads, glitch noise, sparse chimes) drive the soundscape from Koota tension.
- **Pointer/touch raycast** — canvas pointer events raycast onto the active rig, pressing the right control index. Multi-touch supported on mobile.
- **Pattern stabilizer** — fixed-step 30Hz Koota system: spawns patterns, held keycaps pull them back, escapes raise tension, stabilisations raise coherence.
- **Tension driver** — passive decay + high-tension coherence drain + level-up + game-over dispatch.
- **Game-over + restart** — auto-reset after 3s with fresh seed.

Plus a pattern-trails renderer (32-mesh pool mirroring active Pattern entities).

## Verified locally

| Gate | Status |
|---|---|
| lint | 0/0 |
| tsc --noEmit | 0 errors |
| unit tests | 24/24 |
| build | succeeds (Tone adds 61KB gzip) |
| Chrome DevTools: hold 12 keys 3s | tension 1.0 → 0, coherence 25 → 40 |
| Chrome DevTools: idle | tension climbs, game-over fires, auto-restart |

## Bundle delta

Before (v4 merge): three 129KB, three-ext 11KB, physics 32KB, app 19KB, wasm 593KB → ~784KB gzip total

After: +61KB Tone.js audio, +small app growth → ~847KB gzip total. Tone is the only notable addition.

## Follow-ups (not in this PR)

- Rapier-driven sky-rain impacts + keycap spring travel
- three-text rim labels ("MAINTAIN COHERENCE") + keycap face glyphs
- Rotation/wobble gameplay integration (right now they're pure visual)
- Shatter VFX on game-over (currently just freezes + auto-restarts)
- Dedicated collapse audio stem (#42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)