### PR TITLE
feat: rapier-driven sky rain

### DIFF
--- a/src/three/cabinet.ts
+++ b/src/three/cabinet.ts
@@ -119,10 +119,12 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
   physics.timestep = 1 / 60;
   physics.numSolverIterations = 4;
 
-  // Ground plane just below the platter so runaway bodies hit something
-  // and we can cull them (instead of falling forever through the void).
-  const floorBody = physics.createRigidBody(RAPIER.RigidBodyDesc.fixed().setTranslation(0, -3, 0));
-  physics.createCollider(RAPIER.ColliderDesc.cuboid(20, 0.1, 20).setRestitution(0.05), floorBody);
+  // Platter-top surface collider. Sky rain lands on the disc and tumbles
+  // off; the sky rain cull check kicks in a half-meter below so particles
+  // that bounce off the edge have a grace zone before recycle.
+  const platterColliderY = -1.45; // matches IndustrialPlatter top-of-disc.
+  const floorBody = physics.createRigidBody(RAPIER.RigidBodyDesc.fixed().setTranslation(0, platterColliderY, 0));
+  physics.createCollider(RAPIER.ColliderDesc.cylinder(0.16, 1.5).setRestitution(0.25).setFriction(0.6), floorBody);
 
   // ── Cabinet pieces ─────────────────────────────────────────────────────
   const platter = createIndustrialPlatter(scene, {
@@ -132,7 +134,12 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
     outerRadius: 0.6,
     position: new Vector3(0, 0.4, 0),
   });
-  const skyRain = createSkyRain(scene, { count: 160 });
+  const skyRain = createSkyRain(scene, physics, {
+    count: 160,
+    // Recycle particles that bounce/roll off the platter. Platter top sits
+    // at -1.45; give a half-meter grace before culling.
+    floorY: -2.0,
+  });
   const patternTrails = createPatternTrails(scene, kootaWorld);
 
   const initialSchema = kootaWorld.get(Level)?.inputSchema ?? [];

--- a/src/three/sky-rain.ts
+++ b/src/three/sky-rain.ts
@@ -1,18 +1,19 @@
 /**
- * Sky rain — atmospheric enemy cubes (Three.js InstancedMesh).
+ * Sky rain — atmospheric enemy cubes (InstancedMesh synced to rapier bodies).
  *
  * Spec: research/visuals/11-sps-enemies.md
  *
  * Glowing cubes falling from the sky onto the cabinet. Pure atmospheric —
  * they're the visual reinforcement of the AI's distress as tension rises.
- * InstancedMesh batches all N cubes into a single draw call, same as
- * Babylon's SolidParticleSystem.
+ * InstancedMesh batches all N cubes into a single draw call; rapier owns
+ * the simulation (gravity, tumble, impacts against the cabinet floor).
  *
  * At low tension almost nothing falls. At crisis the sky is pouring debris.
  * Occasional red shards appear past tension > 0.5 to communicate critical
  * state (per spec notes).
  */
 
+import RAPIER from '@dimforge/rapier3d';
 import {
   BoxGeometry,
   Color,
@@ -31,45 +32,43 @@ export interface SkyRainOptions {
   spreadRadius?: number;
   /** Y height particles spawn at (they fall from here). */
   spawnY?: number;
-  /** Y height particles are considered "landed" and recycled. */
+  /** Y height below which particles are considered "landed" and recycled. */
   floorY?: number;
-  /** Initial tension 0..1. */
+  /** Initial tension 0..1 — seeds how many in-flight particles exist on frame 0. */
   tension?: number;
 }
 
 export interface SkyRain {
   mesh: InstancedMesh;
-  /**
-   * Drive simulation one frame.
-   * @param deltaSeconds frame time
-   * @param tension 0..1 — faster falls + more spawns at higher values
-   */
   update(deltaSeconds: number, tension: number): void;
   dispose(): void;
 }
 
-interface Particle {
+interface RainParticle {
   alive: boolean;
-  position: Vector3;
-  velocity: Vector3;
-  rotation: Quaternion;
-  angularVel: Vector3;
+  body: RAPIER.RigidBody;
+  collider: RAPIER.Collider;
   color: Color;
   size: number;
 }
 
 const TMP_MATRIX = new Matrix4();
 const TMP_SCALE = new Vector3();
-const CALM_COLOR = new Color(0.2, 0.8, 1.0); // cyan
-const CRISIS_COLOR = new Color(1.0, 0.3, 0.25); // red shard
+const TMP_POS = new Vector3();
+const TMP_QUAT = new Quaternion();
+const CALM_COLOR = new Color(0.2, 0.8, 1.0);
+const CRISIS_COLOR = new Color(1.0, 0.3, 0.25);
 
-export function createSkyRain(scene: Scene, opts: SkyRainOptions = {}): SkyRain {
+/** Hidden below-floor parking spot for dead particles. */
+const PARK_Y = -100;
+
+export function createSkyRain(scene: Scene, physics: RAPIER.World, opts: SkyRainOptions = {}): SkyRain {
   const { count = 160, spreadRadius = 3.0, spawnY = 5.0, floorY = 0.4, tension = 0 } = opts;
 
   const geometry = new BoxGeometry(0.35, 0.35, 0.35);
   const material = new MeshStandardMaterial({
     color: 0x111111,
-    emissive: 0xffffff, // per-instance color overrides this via setColorAt
+    emissive: 0xffffff,
     emissiveIntensity: 1.0,
     transparent: true,
     opacity: 0.8,
@@ -80,15 +79,30 @@ export function createSkyRain(scene: Scene, opts: SkyRainOptions = {}): SkyRain 
   mesh.count = count;
   scene.add(mesh);
 
-  // Initialize all particles dead + parked below the floor
-  const particles: Particle[] = [];
+  // Pre-allocate one rapier body per particle. Bodies start in the "parked"
+  // state — below the floor, static-like, no gravity. Waking one resets
+  // its transform + velocity and enables gravity.
+  const particles: RainParticle[] = [];
   for (let i = 0; i < count; i++) {
+    const bodyDesc = RAPIER.RigidBodyDesc.dynamic()
+      .setTranslation(0, PARK_Y, 0)
+      .setGravityScale(0)
+      .setLinearDamping(0.1)
+      .setAngularDamping(0.05)
+      .setCanSleep(true);
+    const body = physics.createRigidBody(bodyDesc);
+    body.sleep(); // start asleep; no physics cost until woken
+
+    const colliderDesc = RAPIER.ColliderDesc.cuboid(0.175, 0.175, 0.175)
+      .setRestitution(0.35)
+      .setFriction(0.6)
+      .setDensity(1.2);
+    const collider = physics.createCollider(colliderDesc, body);
+
     particles.push({
       alive: false,
-      position: new Vector3(0, -100, 0),
-      velocity: new Vector3(0, 0, 0),
-      rotation: new Quaternion(),
-      angularVel: new Vector3(0, 0, 0),
+      body,
+      collider,
       color: new Color(0, 0, 0),
       size: 0.35,
     });
@@ -99,25 +113,57 @@ export function createSkyRain(scene: Scene, opts: SkyRainOptions = {}): SkyRain 
     const p = particles[i];
     const angle = Math.random() * Math.PI * 2;
     const r = Math.sqrt(Math.random()) * spreadRadius;
-    p.position.set(Math.cos(angle) * r, spawnY + Math.random() * 0.8, Math.sin(angle) * r);
+    const x = Math.cos(angle) * r;
+    const z = Math.sin(angle) * r;
+    const y = spawnY + Math.random() * 0.8;
+
     const fallSpeed = 2.0 + curTension * 4.5;
-    // Slight horizontal drift — stronger at high tension = turbulence
     const driftMag = curTension * 0.6;
-    p.velocity.set((Math.random() - 0.5) * driftMag, -fallSpeed, (Math.random() - 0.5) * driftMag);
-    p.angularVel.set((Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2);
-    p.rotation.set(0, 0, 0, 1);
+
+    p.body.setTranslation({ x, y, z }, true);
+    p.body.setRotation({ x: 0, y: 0, z: 0, w: 1 }, true);
+    p.body.setLinvel(
+      {
+        x: (Math.random() - 0.5) * driftMag,
+        y: -fallSpeed,
+        z: (Math.random() - 0.5) * driftMag,
+      },
+      true,
+    );
+    p.body.setAngvel(
+      {
+        x: (Math.random() - 0.5) * 2,
+        y: (Math.random() - 0.5) * 2,
+        z: (Math.random() - 0.5) * 2,
+      },
+      true,
+    );
+    p.body.setGravityScale(1, true);
+    p.body.wakeUp();
+
     p.size = MathUtils.lerp(0.2, 0.5, Math.random());
-    // Mostly cyan; past half-tension, ~15% chance of a red shard
+    // Collider cuboid half-extents are fixed, but we scale the visible mesh
+    // for size variance. Keeping the collider uniform is cheap and players
+    // won't notice — impact reactions stay consistent.
     const isRed = curTension > 0.5 && Math.random() < 0.15;
     p.color.copy(isRed ? CRISIS_COLOR : CALM_COLOR);
     p.alive = true;
   }
 
+  function parkParticle(i: number): void {
+    const p = particles[i];
+    p.alive = false;
+    p.body.setTranslation({ x: 0, y: PARK_Y, z: 0 }, false);
+    p.body.setLinvel({ x: 0, y: 0, z: 0 }, false);
+    p.body.setAngvel({ x: 0, y: 0, z: 0 }, false);
+    p.body.setGravityScale(0, false);
+    p.body.sleep();
+  }
+
   function update(deltaSeconds: number, curTension: number): void {
     const t = MathUtils.clamp(curTension, 0, 1);
 
-    // Spawn rate scales with tension. Expected spawns per frame at 60fps:
-    //   t=0.0 → 0/s, t=0.5 → 9/s, t=1.0 → 18/s
+    // Spawn rate scales with tension — same curve as before the rapier port.
     const expectedSpawns = deltaSeconds * t * 18;
     const spawnThisFrame = Math.random() < expectedSpawns ? Math.ceil(expectedSpawns) : Math.floor(expectedSpawns);
     let spawned = 0;
@@ -128,23 +174,17 @@ export function createSkyRain(scene: Scene, opts: SkyRainOptions = {}): SkyRain 
       }
     }
 
+    // Read every live particle's rigid-body transform and push it into the
+    // InstancedMesh. Particles that have fallen past the floor get parked.
     for (let i = 0; i < count; i++) {
       const p = particles[i];
       if (!p.alive) continue;
-      p.position.addScaledVector(p.velocity, deltaSeconds);
-      // Integrate rotation. Skip when the angular-velocity vector is
-      // (effectively) zero — normalize() of a zero vector returns NaN and
-      // corrupts the quaternion downstream.
-      const angSpeed = p.angularVel.length();
-      if (angSpeed > 1e-6) {
-        const axis = new Vector3(p.angularVel.x, p.angularVel.y, p.angularVel.z).multiplyScalar(1 / angSpeed);
-        const q = new Quaternion().setFromAxisAngle(axis, angSpeed * deltaSeconds);
-        p.rotation.premultiply(q);
-      }
-
-      if (p.position.y < floorY) {
-        p.alive = false;
-        p.position.set(0, -100, 0);
+      const pos = p.body.translation();
+      if (pos.y < floorY - 0.5) {
+        // Past the floor — park for reuse.
+        parkParticle(i);
+        writeInstance(mesh, i, p);
+        continue;
       }
       writeInstance(mesh, i, p);
     }
@@ -152,13 +192,13 @@ export function createSkyRain(scene: Scene, opts: SkyRainOptions = {}): SkyRain 
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
   }
 
-  // Seed a few active particles so the very first frame has visible rain
-  // (useful for static screenshot tests).
+  // Seed some active particles on mount so the first frame has visible rain.
   const initialActive = Math.ceil(count * tension * 0.5);
   for (let i = 0; i < initialActive; i++) {
     wakeParticle(i, tension);
-    // Disperse them across the fall column so they're not all at the top.
-    particles[i].position.y = MathUtils.lerp(spawnY, floorY + 0.5, Math.random());
+    const pos = particles[i].body.translation();
+    const y = MathUtils.lerp(spawnY, floorY + 0.5, Math.random());
+    particles[i].body.setTranslation({ x: pos.x, y, z: pos.z }, true);
     writeInstance(mesh, i, particles[i]);
   }
   mesh.instanceMatrix.needsUpdate = true;
@@ -167,6 +207,10 @@ export function createSkyRain(scene: Scene, opts: SkyRainOptions = {}): SkyRain 
     mesh,
     update,
     dispose() {
+      for (const p of particles) {
+        physics.removeCollider(p.collider, false);
+        physics.removeRigidBody(p.body);
+      }
       scene.remove(mesh);
       geometry.dispose();
       material.dispose();
@@ -175,10 +219,21 @@ export function createSkyRain(scene: Scene, opts: SkyRainOptions = {}): SkyRain 
   };
 
   // ------- helpers -------
-  function writeInstance(m: InstancedMesh, i: number, p: Particle) {
+  function writeInstance(m: InstancedMesh, i: number, p: RainParticle) {
+    if (!p.alive) {
+      // Force-hide parked particles off-screen.
+      TMP_MATRIX.makeTranslation(0, PARK_Y, 0);
+      m.setMatrixAt(i, TMP_MATRIX);
+      m.setColorAt(i, new Color(0, 0, 0));
+      return;
+    }
+    const pos = p.body.translation();
+    const rot = p.body.rotation();
+    TMP_POS.set(pos.x, pos.y, pos.z);
+    TMP_QUAT.set(rot.x, rot.y, rot.z, rot.w);
     TMP_SCALE.setScalar(p.size);
-    TMP_MATRIX.compose(p.position, p.rotation, TMP_SCALE);
+    TMP_MATRIX.compose(TMP_POS, TMP_QUAT, TMP_SCALE);
     m.setMatrixAt(i, TMP_MATRIX);
-    m.setColorAt(i, p.alive ? p.color : new Color(0, 0, 0));
+    m.setColorAt(i, p.color);
   }
 }


### PR DESCRIPTION
Moves sky rain from hand-rolled velocity integration to rapier rigid bodies. Each particle is now a dynamic cuboid with a collider that sleeps while parked and wakes on spawn. Adds a platter-top cylinder collider at y=-1.45 so rain lands on the disc, tumbles realistically, and rolls off the edge.

## Evidence

At tension=0.8 rain lands on the platter and settles briefly before rolling off. Screenshot verified via Chrome DevTools MCP.

## Tradeoffs

- Per-particle rapier body is heavier than a plain Vector3 loop, but sleeping parked bodies cost ~nothing and 160 awake cuboids is well inside rapier's budget
- Slight behavior change: cubes bounce + tumble instead of disappearing at y<floor. Intentional — matches the "heavy industrial debris" read.

## Gates

- \`pnpm lint\` / \`tsc\` / \`test\` / \`build\` — all clean locally
- No bundle delta (rapier already loaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)