### PR TITLE
feat: shatter VFX, three-quarter camera, doc sweep + LORE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,20 +14,22 @@ domain: context
 
 ## Project Brief
 
-Cognitive Dissonance is a haunting interactive 3D experience where you hold a
-fragile glass AI mind together as its own thoughts try to escape. It plays in
-any modern browser and ships to iOS/Android via Capacitor wrapping the web
-build.
+Cognitive Dissonance is a **cabinet engine** — a single fixed chassis
+(industrial platter, recessed glass AI sphere, machined rim, postprocessed
+corruption sky) that hosts many games. Each level declares an `inputSchema`
+and the cabinet materialises matching controls through the rim. Plays in any
+modern browser; ships to iOS/Android via Capacitor wrapping the web build.
 
-### Core Loop
+See [docs/LORE.md](./docs/LORE.md) for the narrative substrate.
 
-1. Glass sphere with celestial nebula shader sits on heavy industrial platter
-2. Corruption patterns (colored tendrils) escape from sphere center to rim
-3. Hold matching colored keycaps on the platter to pull them back
-4. Missed patterns spawn holographic SDF enemies (neon-raymarcher + crystalline-cube)
-5. Enemies reaching sphere = tension spike + glass degradation
-6. At 100% tension → sphere shatters → "COGNITION SHATTERED" → game over
-7. Endless with logarithmic advancement, high replay value from buried seed
+### Default Loop (pattern-match level)
+
+1. Glass sphere + nebula shader sits in the recess at platter centre
+2. Corruption patterns escape from the sphere as colored tendrils
+3. Hold the matching colored keycap to pull the pattern back
+4. Sky rain impacts the sphere — each impact bumps tension up
+5. Tension drains coherence above 0.75; coherence at 0 = shatter
+6. Shatter detonates a 48-shard rapier-driven glass pool; restart resets
 
 ---
 
@@ -36,60 +38,68 @@ build.
 ### Architecture
 
 ```
-Vite 8 (static export)
-├── index.html (root)
-├── src/main.tsx (React entry, no SSR)
-├── GameBoard (2D React + Tailwind 4)
-│   ├── ATCShader background
-│   ├── Title / Clarity / Game-over overlays
-│   └── Accessibility live regions
-├── GameScene (Reactylon Engine/Scene)
-│   ├── Declarative: hemisphericLight, pointLight, arcRotateCamera
-│   ├── AISphere (glass + celestial shader)
-│   ├── Platter (industrial base + GSAP garage-door keycaps)
-│   ├── PatternStabilizer (core gameplay)
-│   ├── EnemySpawner (Yuka AI + SDF shader enemies)
-│   ├── PostProcessCorruption (chromatic aberration + noise)
-│   ├── SPSEnemies (SolidParticleSystem visuals)
-│   ├── DiegeticGUI (coherence ring on platter)
-│   ├── SpatialAudio (event-driven procedural SFX)
-│   └── AudioEngine (Tone.js adaptive score)
-└── ECS (Koota)
-    └── Single world (src/sim/world.ts) holds BOTH:
-        ├── Singleton traits (state replacing Zustand)
-        │   Game  — phase, restartToken
-        │   Level — currentLevel, coherence, peakCoherence, tension
-        │   Seed  — seedString, lastSeedUsed, seedrandom rng
-        │   Input — heldKeycaps (Set<number>)
-        │   Audio — isInitialized, tension, Tone.js graph
-        └── Entity traits (replacing Miniplex)
-            IsSphere, IsEnemy, IsPattern   (tags)
-            Position, Velocity              (spatial)
-            Enemy, Pattern, Sphere          (data)
+Vite 8 (static export to dist/)
+├── index.html          single canvas, no DOM UI
+└── src/
+    ├── main.ts         entry — creates canvas, world, cabinet, rAF loop
+    ├── three/          cabinet pieces
+    │   ├── cabinet.ts          orchestrator (scene/camera/physics/renderer)
+    │   ├── industrial-platter.ts
+    │   ├── ai-core.ts          glass sphere + nebula
+    │   ├── sky-rain.ts         rapier-driven debris pool
+    │   ├── shatter.ts          48-shard glass pool for game-over
+    │   ├── emergent-controls.ts level-parameterized control rig
+    │   ├── pattern-trails.ts    visualises Pattern entities
+    │   └── post-process-corruption.ts
+    ├── sim/            game logic
+    │   ├── world.ts    Koota world + singleton trait initialisation
+    │   ├── traits.ts   all trait definitions (singletons + entities)
+    │   ├── actions.ts  discrete mutations (setPhase, generateNewSeed, ...)
+    │   └── systems/
+    │       ├── pattern-stabilizer.ts (fixed 30Hz)
+    │       └── tension-driver.ts     (per-frame)
+    ├── boot/           side-effect listeners (audio, input, game-over)
+    └── lib/            shaders, RNG, math helpers
 ```
+
+### Koota traits
+
+Singletons (attached to the world entity, replace stores entirely):
+- `Game` — `phase`, `restartToken`
+- `Level` — `currentLevel`, `coherence`, `peakCoherence`, `tension`,
+  `inputSchema`, `rotation`, `wobble`
+- `Seed` — `seedString`, `lastSeedUsed`, seedrandom rng
+- `Input` — `heldKeycaps: Set<number>`
+- `Audio` — `isInitialized`, `tension`, Tone.js graph
+
+Entity traits (composed at spawn):
+- Tags: `IsSphere`, `IsEnemy`, `IsPattern`
+- Spatial: `Position`, `Velocity`
+- Data: `Enemy`, `Pattern`, `Sphere`
 
 ### Key Patterns
 
-- **Imperative 3D**: All Babylon meshes/materials created in `useEffect`, not JSX.
-  Reactylon JSX is reserved for lights and camera only.
-- **Reactylon JSX**: Lowercase tags (`<hemisphericLight>`, `<arcRotateCamera>`)
-  get their Babylon classes auto-registered via `babel-plugin-reactylon` running
-  inside `@vitejs/plugin-react`'s Babel pass.
-- **Render loop**: `scene.onBeforeRenderObservable.add(fn)` + cleanup in the
-  effect teardown. Never driven by React's render cycle.
-- **GSAP + Babylon**: `gsap.to(mesh.position, {...})` works natively with
-  Babylon's `Vector3` — no adapter layer.
-- **CSP-safe shaders**: All GLSL lives in `BABYLON.Effect.ShadersStore` as
-  static string literals. CSP allows `wasm-unsafe-eval` (Havok physics) +
-  `unsafe-eval` (Koota JIT trait accessors).
-- **Store shim layer**: `src/store/*-store.ts` preserves the Zustand call-site
-  API (`getState()`, `setState()`, `subscribe()`, hook-form) but proxies every
-  operation through Koota `world.get/set/onChange`. This let us migrate state
-  ownership without touching 20+ consuming components. Entity data similarly
-  goes through `src/game/world.ts` as a compat shim over Koota's `spawn/destroy`.
-- **Phase gating**: gameplay systems (enemy-spawner, pattern-stabilizer,
-  ai-sphere's tension loop) early-return outside `phase === 'playing'`.
-  Prevents tension rise during title/loading/game-over.
+- **Zero UI framework** — no React/Vue/Reactylon. Cabinet renders directly to
+  a single canvas. The cabinet IS the menu.
+- **Cabinet engine framing** — the chassis (platter, sphere, rain, corruption)
+  is shared across every level. Per-level variation goes through
+  `Level.inputSchema` and a system in `src/sim/systems/`. See STANDARDS.md.
+- **rAF render loop** — `cabinet.render(dt)` is called from
+  `requestAnimationFrame` in main.ts. Steps physics with a 60Hz substep
+  accumulator (max 5 substeps per frame), updates Koota systems, and runs
+  the postprocess composer.
+- **Rapier physics** — kinematic collider for the AI sphere with
+  `CONTACT_FORCE_EVENTS` so rain impacts can drive tension. Dynamic colliders
+  for sky rain particles and shatter shards. WASM emitted to `dist/assets/`
+  via `vite-plugin-wasm`.
+- **CSP-safe shaders** — GLSL lives as static string literals registered with
+  three's `ShaderMaterial` at module import time. CSP permits
+  `wasm-unsafe-eval` (rapier) and `unsafe-eval` (Koota JIT trait accessors).
+- **Phase gating** — gameplay systems early-return outside `phase ===
+  'playing'`. Prevents tension rise during title/loading/game-over.
+- **Bridge for tests** — `src/main.ts` exposes `__world`, `__cabinet`,
+  `__setTension`, `__getLevel`, `__fireGameOver` on `window` so Playwright
+  E2E specs can drive the sim without UI.
 
 ---
 
@@ -98,16 +108,16 @@ Vite 8 (static export)
 | Technology     | Version | Purpose                                  |
 |----------------|---------|------------------------------------------|
 | Vite           | 8.0     | Bundler, dev server, static export       |
-| React          | 19.2    | UI components                            |
 | TypeScript     | 5.9     | Type safety                              |
-| Babylon.js     | 8.56    | 3D rendering engine                      |
-| Reactylon      | 3.5.4   | Declarative Babylon.js + React           |
-| Koota          | 0.6.6   | ECS — state + entity data                |
-| GSAP           | 3.14    | Mechanical animations                    |
-| Tone.js        | 15      | Adaptive spatial audio                   |
-| Yuka.js        | 0.7     | Enemy AI behaviors                       |
+| three.js       | 0.183   | 3D rendering (raw, no framework wrapper) |
+| @dimforge/rapier3d | 0.19 | Physics (WASM via vite-plugin-wasm)      |
+| postprocessing | 6.39    | Corruption EffectComposer pipeline       |
+| three-stdlib   | 2.36    | RoomEnvironment for PMREM                |
+| Koota          | 0.6.6   | ECS — singleton state + entity systems   |
+| GSAP           | 3.14    | Mechanical motion curves                 |
+| Tone.js        | 15      | Adaptive audio score                     |
+| Yuka.js        | 0.7     | Enemy AI steering                        |
 | seedrandom     | 3.0     | Deterministic procedural generation      |
-| Tailwind CSS   | 4       | 2D overlay styling                       |
 | Biome          | 2.4     | Linting + formatting                     |
 | Vitest         | 4.1     | Unit + browser component tests           |
 | Playwright     | 1.59    | E2E tests                                |
@@ -116,13 +126,13 @@ Vite 8 (static export)
 ### Commands
 
 ```bash
-pnpm dev               # Vite dev server (~200ms startup)
+pnpm dev               # Vite dev server
 pnpm build             # Production static build (dist/)
-pnpm start             # Vite preview of dist/
+pnpm start             # Vite preview of dist/ on :3000
 pnpm lint              # Biome check
 pnpm test              # Vitest unit tests
-pnpm test:browser      # Vitest browser mode — real WebGL tests
-pnpm test:e2e          # Playwright E2E (xvfb on Linux, direct on macOS)
+pnpm test:browser      # Vitest browser mode — real WebGL via Playwright
+pnpm test:e2e          # Playwright E2E
 pnpm cap:sync:ios      # Build web → sync to ios/
 pnpm cap:sync:android  # Build web → sync to android/
 ```
@@ -131,79 +141,75 @@ pnpm cap:sync:android  # Build web → sync to android/
 
 ## Development History
 
+### v4.0.0 — Zero-framework cabinet (April 2026)
+
+PR #204 — ground-up rebuild: dropped Babylon + Reactylon entirely; raw three.js
++ rapier + postprocessing in a single canvas. No UI framework. The cabinet is
+the menu. Bundle: 190KB JS + 593KB cacheable WASM.
+
+Subsequent PRs on the v4 stack:
+- #205 — playable loop: audio, pointer raycast, pattern stabilizer, tension
+  driver, game-over flow
+- #206 — rapier-driven sky rain (replaced hand-rolled integration)
+- #207 — diegetic rim etching ("MAINTAIN COHERENCE") via CanvasTexture
+- #208 — rain impacts on sphere bump tension (CONTACT_FORCE_EVENTS)
+- #209 — shatter VFX on game-over + three-quarter camera framing
+
 ### v3.0.0 — Vite + Koota migration (April 2026)
 
-Two big architectural moves shipped together on PR #201:
+PR #201 retired Next.js (basePath gymnastics, Turbopack/Webpack split, slow
+HMR) for Vite 8, and unified state/entities under Koota (replacing Zustand +
+Miniplex). Old store APIs survived via thin shims; v4 dropped the shims when
+the UI framework went away.
 
-**Next.js 16 → Vite 8** — this is a client-side WebGL game, not a web app.
-Dropping Next.js removed basePath gymnastics, Turbopack/Webpack split, babel-
-for-users/swc-for-internals, and dev-server slowness (~60s first compiles
-under HMR). Vite gives us instant HMR, single build pipeline, ~10s production
-build, clean static `dist/` for Capacitor to wrap.
-
-**Zustand + Miniplex → Koota ECS** — single world is now the source of truth
-for both global state (singleton traits) and game entities (spawnable entities
-with trait composition). The old stores kept their API via thin shims that
-proxy through Koota, so migration was drop-in at call sites. Traits, world,
-and actions live in `src/sim/`.
-
-Also in v3:
-- Capacitor 8.3 native wrapping (iOS + Android) replacing aborted RN scaffolding
-- Responsive camera (phone portrait gets wider framing), ResizeObserver on canvas
-- Cross-platform E2E runner (xvfb on Linux, direct on macOS)
-- pnpm 10.33, lockfile regenerated, all GitHub Actions pinned to exact SHAs
-- Branch protection on `main` requiring "CI Success"
-- Accessibility viewport fix (re-enabled browser zoom)
-- ECS entity scaffolding: IsSphere/IsEnemy/IsPattern tags + Enemy/Pattern/Sphere data
+Also in v3: Capacitor 8.3 native wrapping, responsive camera, cross-platform
+E2E runner, branch protection on main requiring "CI Success", all GitHub
+Actions pinned to exact SHAs.
 
 ### v2.0.0 — Babylon.js + Reactylon (Feb 2026)
 
-Complete ground-up rebuild from Vite + R3F + Three.js to Next.js + Babylon +
-Reactylon. (The Vite reintroduction in v3 is coincidental — v2 had moved to
-Next.js first; v3 restored Vite after the architectural reasoning.)
-
-Key v2 design decisions still in force:
-1. **De-humanized the AI** — Replaced NS-5 android bust with fragile glass sphere
-2. **Pattern stabilization** — Core mechanic: hold keycaps to pull back corruption
-3. **Buried seed** — Hidden deterministic seed drives all procedural generation
-4. **Garage-door keycaps** — Mechanical emergence from platter rim with GSAP
+Ground-up rebuild from R3F to Next.js + Babylon + Reactylon. Established the
+load-bearing creative decisions still in v4:
+1. **De-humanized AI** — fragile glass sphere instead of a humanoid bust
+2. **Pattern stabilization** as the core mechanic
+3. **Buried deterministic seed** drives procedural generation
+4. **Garage-door keycaps** rising mechanically through the rim
 5. **Symmetric titles** — "COGNITIVE DISSONANCE" → "COGNITION SHATTERED"
 
-### v1.0.0 — Original R3F Version
+### v1.0.0 — Original R3F version
 
-Vite + React Three Fiber + Three.js + Miniplex + Web Worker game loop.
-Raymarched SDF enemies, 3D mechanical keyboard, NS-5 android bust.
+Vite + React Three Fiber + Miniplex + Web Worker game loop. Raymarched SDF
+enemies, 3D mechanical keyboard, NS-5 android bust. Superseded by v2.
 
 ---
 
 ## Known Issues
 
-- Physics-keys constrained via Havok 6DoF; tune
-  `src/components/physics-keys.tsx` constraint keys `LINEAR_Y.minLimit/maxLimit`
-  (travel) and `LINEAR_Y.stiffness/damping` + `setAxisMotorMaxForce` (spring),
-  then validate via `pnpm test:e2e:headed` visual QA pass.
-- XR hand tracking is stub only — pinch→keycap mapping not wired.
-- Mobile touch: keycap hit areas may need enlargement on small phones.
-- SonarCloud in CI sometimes flakes due to rate-limited token — non-blocking,
-  doesn't fail `CI Success`.
+- SonarCloud "Automatic Analysis enabled" admin warning fails the SonarCloud
+  job on every CI run. Non-blocking — `CI Success` doesn't depend on it. Real
+  fix is in SonarCloud project settings (disable Automatic Analysis).
+- E2E bridge tier (specs that wait for `window.__world`) is skipped in CI on
+  SwiftShader because rapier WASM init takes ~30s under software rendering.
+  Canvas tier always runs and gives smoke coverage.
+- Android APK builds but `native/App.tsx` shell hasn't been wired to game
+  components — the APK opens to an empty scene. iOS works through Capacitor's
+  WebView.
 
 ---
 
 ## Active Decisions
 
-- **Vite 8** — Client-side-only game; no SSR; no routes. Next.js overhead
-  wasn't paying for itself.
-- **Koota ECS** — One world for state + entities. Traits > stores.
-- **Biome 2.4** — Replaces ESLint. Single binary, zero plugin deps.
-- **`forceWebGL={true}`** — Safest path for complex GLSL raymarchers.
-- **Koota shim layer** — Keeps Zustand call-site API while state moves to
-  Koota traits. Enables future refactor to `useTrait`/`useQuery` without a
-  flag-day migration.
+- **Cabinet engine framing** — see STANDARDS.md "Architectural North Star".
+  Adding new gameplay = new `inputSchema` + new system. Never new render path.
+- **Vite 8** — client-side-only WebGL game; no SSR; no routes.
+- **Raw three.js** — no UI framework. The cabinet renders to a single canvas.
+- **Koota ECS** — one world owns both global state (singletons) and entities.
+- **Rapier3D** — physics chosen via research (see docs/PHYSICS_RESEARCH.md).
+  Fixed-step substep accumulator, contact-force events for impact-driven
+  tension.
+- **Biome 2.4** — replaces ESLint. Single binary, zero plugin deps.
 - **GSAP for mechanical animations** — CustomEase, timeline, stagger.
-- **Tone.js exclusive audio** — Babylon audio engine disabled.
-- **Capacitor, not React Native** — We wrap the web build in a WebView; no
-  separate native codebase.
-- **pnpm 10.33** — Package manager. `onlyBuiltDependencies: ["sharp"]` in
-  package.json so CI's strict build-script policy doesn't fail install.
-- **Exact SHA pins for all GitHub Actions** — Floating refs forbidden.
+- **Tone.js exclusive audio** — no other audio engine.
+- **Capacitor, not React Native** — we wrap the web build in a WebView.
+- **Exact SHA pins for all GitHub Actions** — floating refs forbidden;
   Dependabot manages updates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,63 +38,63 @@ pnpm cap:sync:android  # Build web + sync to android/
 
 ## Key Architecture Decisions
 
-- **Vite 8**: Bundler, dev server, static export. Client-side only — no SSR,
-  no routes. Migrated from Next.js 16 in v3 because Next's overhead wasn't
-  earning its keep.
-- **Babylon.js 8 + Reactylon 3.5**: Declarative React bindings for Babylon.
-- **babel-plugin-reactylon**: Auto-registers Babylon classes for lowercase
-  JSX tags. Runs inside `@vitejs/plugin-react` v4's Babel pass.
-- **Imperative mesh creation**: All 3D objects created in `useEffect`, not
-  JSX (except lights + camera).
-- **Render loop**: `scene.onBeforeRenderObservable.add(fn)` with cleanup in
-  the effect's teardown. Never driven by React render cycle.
-- **GSAP for animations**: `gsap.to(mesh.position, {...})` works natively
-  with Babylon's Vector3.
-- **CSP-safe shaders**: All GLSL in `BABYLON.Effect.ShadersStore` as static
-  string literals. CSP permits `wasm-unsafe-eval` (Havok physics) + `unsafe-eval`
-  (Koota JIT trait accessors).
-- **Koota ECS for state**: Single world holds global singleton traits (Game,
-  Level, Seed, Input, Audio) + entity traits (IsSphere/IsEnemy/IsPattern +
-  Position/Enemy/Pattern data). Replaces both Zustand and Miniplex in v3.
-- **Store shim layer**: `src/store/*-store.ts` preserves the Zustand call-site
-  API but routes through Koota. Keeps migration non-invasive.
-- **Tone.js exclusive**: Babylon audioEngine disabled, Tone.js handles all
-  sound.
-- **Biome 2.4**: Linting + formatting (replaced ESLint — single binary, zero
-  plugin deps).
+- **Cabinet engine framing** — see [STANDARDS.md](./STANDARDS.md) and
+  [docs/LORE.md](./docs/LORE.md). One chassis (platter, sphere, rain,
+  corruption); per-level variation through `Level.inputSchema` + a system in
+  `src/sim/systems/`. Never new render paths per game.
+- **Vite 8**: Bundler, dev server, static export to `dist/`. Client-side only —
+  no SSR, no routes.
+- **Raw three.js 0.183**: No UI framework wrapper. The cabinet renders to a
+  single canvas; the cabinet IS the menu.
+- **Render loop**: `requestAnimationFrame` calls `cabinet.render(dt)` from
+  `src/main.ts`. Never driven by any framework render cycle.
+- **Rapier3D physics**: WASM emitted via `vite-plugin-wasm`. Fixed 60Hz step
+  with substep accumulator (max 5 substeps/frame). Sphere is a kinematic
+  collider with `CONTACT_FORCE_EVENTS` so rain impacts can drive tension.
+- **GSAP for animations**: CustomEase for mechanical motion (keycaps, platter).
+- **CSP-safe shaders**: All GLSL lives as static string literals registered
+  with three's `ShaderMaterial`. CSP permits `wasm-unsafe-eval` (rapier) and
+  `unsafe-eval` (Koota JIT trait accessors).
+- **Koota ECS**: Single world owns both global singleton traits (Game, Level,
+  Seed, Input, Audio) and entity traits (IsSphere/IsEnemy/IsPattern +
+  Position/Enemy/Pattern data). Replaces Zustand and Miniplex.
+- **Tone.js exclusive**: All audio. First-gesture initialised from `boot/audio.ts`.
+- **Biome 2.4**: Linting + formatting.
 - **Capacitor 8.3**: Native iOS + Android by wrapping the Vite web build in
   a WebView. Not React Native.
 
 ## Conventions
 
-- Tailwind CSS 4 for 2D overlays
 - System monospace fonts (Courier New) — no external font dependencies
-- Lowercase Reactylon JSX tags: `<hemisphericLight>`, `<arcRotateCamera>`,
-  `<pointLight>`
-- `pnpm` package manager (no `packageManager` pin in package.json — CI
-  installs latest via `pnpm/action-setup@v6.0.0`'s `version: latest`)
-- All game code under `src/`; sim layer under `src/sim/`
+- `pnpm` package manager
+- All game code under `src/`; cabinet under `src/three/`; sim under `src/sim/`
 
 ## File Structure
 
 ```
-index.html       Vite HTML entry
+index.html       Vite HTML entry — single canvas, no DOM UI
 src/
-  main.tsx       React root (createRoot + GameBoard)
-  styles.css     Tailwind + global styles
-  components/    All game components (3D + 2D)
-  sim/           Koota world, traits, actions
+  main.ts        Entry — creates canvas, world, cabinet, rAF loop
+  three/         Cabinet pieces
+    cabinet.ts          orchestrator (scene/camera/physics/renderer/composer)
+    industrial-platter.ts
+    ai-core.ts          glass sphere + nebula shader
+    sky-rain.ts         rapier-driven debris pool
+    shatter.ts          48-shard glass pool for game-over
+    emergent-controls.ts level-parameterized control rig
+    pattern-trails.ts    visualises Pattern entities
+    post-process-corruption.ts
+  sim/           Koota world, traits, systems
     world.ts     createWorld() + Game/Level/Seed/Input/Audio singletons
-    traits.ts    All trait definitions (singleton + entity)
-    actions.ts   Discrete mutations (setPhase, setTension, generateNewSeed, ...)
-  store/         Koota-backed shims preserving Zustand API shape
-  game/          Miniplex-compat shim over Koota (world.add/remove)
-  lib/           Utilities + shader definitions (GLSL)
-  types/         TypeScript declarations
+    traits.ts    All trait definitions
+    actions.ts   Discrete mutations
+    systems/     pattern-stabilizer (30Hz), tension-driver (per-frame)
+  boot/          First-gesture audio + input + game-over listeners
+  lib/           Shader sources, RNG, math helpers
 e2e/             Playwright E2E tests (smoke, gameplay, governor)
 android/         Capacitor Android project (synced from dist/)
 ios/             Capacitor iOS project (synced from dist/)
-docs/            Architecture, design, deployment, state
+docs/            Architecture, design, lore, deployment, state
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -6,38 +6,40 @@ ships as iOS + Android native apps via Capacitor.
 
 ## Stack
 
-- **Next.js 16** (Turbopack dev, Webpack prod, static export) — App Router
-- **Babylon.js 8.56** + **Reactylon 3.5** — declarative 3D React bindings
-- **GSAP 3.14** — mechanical animations (keycaps, platter, CustomEase)
-- **Tone.js 15** — adaptive spatial audio score
-- **Zustand 5** — state (tension, coherence, seed, input)
-- **Miniplex 2** — ECS for game entities
-- **Yuka 0.7** — enemy AI behaviors
-- **Capacitor 8.3** — iOS + Android native wrapping (WebView bridge)
-- **Tailwind CSS 4** — 2D overlay styling
-- **Biome 2.4** — lint + format (replaced ESLint)
+- **Vite 8** — bundler + dev server + static build (no SSR, no routes)
+- **Three.js 0.183** — raw three.js, no UI framework wrapper
+- **Rapier3D 0.19** (WASM via `vite-plugin-wasm`) — physics for sky rain,
+  sphere impacts, and glass shatter shards
+- **postprocessing 6.39** — corruption effect pipeline
+- **Koota 0.6** — ECS for both singleton state and entity systems (replaces
+  the prior Zustand + Miniplex split)
+- **GSAP 3.14** — mechanical motion curves (keycaps, platter, CustomEase)
+- **Tone.js 15** — adaptive audio score (drone, pads, glitch noise, chimes)
+- **Yuka 0.7** — enemy AI steering
+- **Capacitor 8.3** — iOS + Android native wrapping (WebView around `dist/`)
+- **Biome 2.4** — lint + format
 - **Vitest 4** (unit + browser mode) + **Playwright** (E2E)
 
 ## Getting started
 
 ```bash
 pnpm install
-pnpm dev          # Turbopack dev server (~440ms startup)
+pnpm dev          # Vite dev server
 ```
 
-Open [http://localhost:3000](http://localhost:3000).
+Open [http://localhost:5173](http://localhost:5173).
 
 ## Commands
 
 ```bash
-pnpm dev               # Dev server (Turbopack)
-pnpm build             # Production build (static export ~11s)
-pnpm start             # Production server
+pnpm dev               # Vite dev server
+pnpm build             # Production static build (dist/)
+pnpm start             # Vite preview of dist/ on :3000
 pnpm lint              # Biome check (0 errors, 0 warnings)
 pnpm lint:fix          # Biome auto-fix
-pnpm test              # Vitest unit tests (60 tests)
-pnpm test:browser      # Vitest browser mode — real WebGL (48 tests)
-pnpm test:e2e          # Playwright E2E via xvfb-run (17 tests)
+pnpm test              # Vitest unit tests
+pnpm test:browser      # Vitest browser mode — real WebGL via Playwright
+pnpm test:e2e          # Playwright E2E (canvas tier always; bridge tier skipped in CI)
 ```
 
 ### Native (Capacitor)
@@ -58,31 +60,34 @@ are exposed via Capacitor plugins.
 ## Architecture
 
 ```
+index.html        Vite HTML entry — single canvas, no DOM UI
 src/
-  app/            Next.js App Router (layout, page, globals.css)
-  components/     Game components (3D + 2D)
-  store/          Zustand stores (seed, level, audio, game, input)
-  lib/            Utilities + shader definitions (GLSL)
-  game/           Miniplex ECS world
-  types/          TypeScript declarations
-e2e/              Playwright E2E tests
-android/          Capacitor Android project (auto-synced)
-ios/              Capacitor iOS project (auto-synced)
-docs/             Architecture, design, deployment
+  main.ts         Entry: creates canvas, world, cabinet, rAF loop
+  three/          Cabinet pieces (platter, AI core, sky rain, shatter,
+                  emergent controls, post-process corruption)
+  sim/            Koota world + traits + systems (pattern stabilizer,
+                  tension driver)
+  boot/           First-gesture audio + input listeners + game-over hook
+  lib/            Shader sources, RNG, math helpers
+e2e/              Playwright E2E (smoke, gameplay, governor)
+android/          Capacitor Android project (synced from dist/)
+ios/              Capacitor iOS project (synced from dist/)
+docs/             Architecture, design, lore, deployment
 ```
 
 ## Game design
 
-A **fragile glass sphere** containing a **celestial nebula shader** sits on a
-**heavy industrial black metal platter**. The sphere degrades from calm blue
-to violent red as tension rises. **Corruption patterns** (colored tendrils)
-escape from the sphere center toward the rim. Hold matching colored keycaps
-on the platter to pull them back. Missed patterns spawn **holographic SDF
-enemies**. At 100% tension the sphere shatters — "COGNITION SHATTERED."
+The game is a **cabinet engine** — a single chassis (industrial platter,
+recessed glass AI sphere, machined rim with input slits, postprocessed
+corruption sky) that hosts many games. Each level declares an
+`inputSchema` and the cabinet materialises matching controls through the
+rim. See [docs/LORE.md](./docs/LORE.md) for the full framing and
+[docs/DESIGN.md](./docs/DESIGN.md) for the visual rules.
 
-Everything is diegetic — no HUD. Coherence displays as a glowing ring on the
-platter. Audio evolves from calm drone to frantic glitch percussion. Endless
-with logarithmic advancement, high replay from a buried deterministic seed.
+Default loop: pattern-match. Patterns escape the sphere as colored
+tendrils. Hold the matching keycap to pull them back. Tension ramps from
+rain impacts and unsuppressed leaks; when coherence drains to zero the
+glass shatters and the shift restarts. Everything is diegetic — no HUD.
 
 ## Documentation
 
@@ -92,6 +97,7 @@ with logarithmic advancement, high replay from a buried deterministic seed.
 - [docs/STATE.md](./docs/STATE.md) — Current project state and roadmap
 - [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) — System design
 - [docs/DESIGN.md](./docs/DESIGN.md) — Visual vision and identity
+- [docs/LORE.md](./docs/LORE.md) — Narrative substrate and Cabinet Engine
 - [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md) — Deploy procedures
 
 ## License

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,6 +1,6 @@
 ---
 title: Standards
-updated: 2026-04-13
+updated: 2026-04-14
 status: current
 domain: quality
 ---
@@ -10,6 +10,24 @@ domain: quality
 Non-negotiable rules for this codebase. Enforced by CI (Biome lint, TypeScript,
 Vitest, Playwright) and by reviewer judgment. A PR that violates any of these
 does not merge.
+
+## The Cabinet Engine (Architectural North Star)
+
+Cognitive Dissonance is **a cabinet engine, not a single game.** The chassis is
+fixed: industrial platter, recessed glass AI sphere, machined rim with input
+slits, postprocessed corruption sky. That chassis never changes.
+
+What changes per level is the **input schema** (`Level.inputSchema`) declared
+on the Koota world — and the cabinet materialises matching controls through
+the rim. One cabinet, many games. See [docs/LORE.md](./docs/LORE.md) for the
+full framing and [docs/DESIGN.md](./docs/DESIGN.md) for visual rules.
+
+This framing is load-bearing for every architectural choice:
+- Three.js + rapier are the chassis runtime — never coupled to a level.
+- New gameplay = a new `inputSchema` + a new system in `src/sim/systems/`.
+  Never a new render path, never a new scene, never a new entry point.
+- The platter, AI sphere, sky rain, corruption shader are **shared state**
+  consumed by every level. Don't fork them per-game.
 
 ## Code quality
 
@@ -49,30 +67,31 @@ The game's aesthetic is **diegetic, industrial, deliberate.** No exceptions.
 
 ## Architecture
 
-- **All 3D creation is imperative.** Declarative JSX for lights and cameras
-  only. Meshes, materials, particle systems, and shader materials are created
-  in `useEffect`, registered to the scene, and disposed in the cleanup
-  function. Reactylon's reconciler is not trusted with complex lifecycles.
-- **Render loop integration is via `scene.registerBeforeRender(fn)` /
-  `unregisterBeforeRender(fn)`.** Never via React's render cycle. The game
-  runs at engine framerate, independent of React commits.
-- **State in Zustand stores.** Game logic reads from stores inside the render
-  loop via `useGameStore.getState()` (the synchronous snapshot) — never via
-  hooks, which would couple frame updates to React commits.
-- **CSP-safe shaders.** All GLSL source lives in `BABYLON.Effect.ShadersStore`
-  as static string literals at module import time. No dynamic
-  `eval`-equivalents, no runtime shader construction from user input.
-- **Turbopack dev, Webpack prod.** Do not regress this — Babel (for
-  `babel-plugin-reactylon`) runs on user code in both modes; Next.js internals
-  always use SWC. Benchmarked dev startup: 440ms.
+- **Zero UI framework.** No React, no Vue, no Reactylon. The cabinet renders
+  via raw three.js into a single canvas; the cabinet IS the menu.
+  `src/three/cabinet.ts` owns the scene graph; `src/main.ts` owns the canvas
+  and the rAF loop.
+- **Render loop is rAF-driven.** `requestAnimationFrame` calls
+  `cabinet.render(dt)` which steps physics, advances Koota systems, and
+  composes the postprocessing pipeline. No React commit cycle to interfere.
+- **Physics is rapier3d.** Fixed 60Hz step with substep accumulator (max 5
+  substeps per frame). Kinematic colliders for the AI sphere; dynamic for sky
+  rain and shatter shards. WASM is emitted to `dist/assets/` via
+  `vite-plugin-wasm`.
+- **State is Koota ECS.** Singleton traits (`Game`, `Level`, `Input`, `Audio`,
+  `Seed`) on the world entity replace Zustand. Entity traits (`IsSphere`,
+  `Pattern`, `Position`, etc.) drive per-entity systems. Renderers query;
+  systems mutate.
+- **Shaders are static GLSL string literals.** Defined at module import time
+  in `src/lib/shaders/*` and registered with three's `ShaderMaterial`. No
+  runtime shader construction from user input — CSP must permit only
+  `wasm-unsafe-eval` (rapier) and `unsafe-eval` (Koota JIT trait accessors).
 
 ## Native (Capacitor)
 
-- **Capacitor wraps the web build.** Not React Native, not Cordova. The
-  `out/` directory from `next build` is the entire native app; Capacitor's
-  WebView loads `index.html` and the Capacitor plugins bridge to native APIs.
-- **Web build must produce `out/` with `output: 'export'`** when
-  `GITHUB_PAGES=true`. Static export is required for Capacitor to package it.
+- **Capacitor wraps the Vite static build.** The `dist/` directory from
+  `vite build` is the entire native app; Capacitor's WebView loads
+  `index.html` and the Capacitor plugins bridge to native APIs.
 - **Don't import native-only plugins unconditionally.** Use
   `Capacitor.isNativePlatform()` to gate Device/Haptics/StatusBar calls so the
   same bundle runs on web without crashing.

--- a/docs/LORE.md
+++ b/docs/LORE.md
@@ -1,0 +1,91 @@
+---
+title: Lore
+updated: 2026-04-14
+status: current
+domain: creative
+---
+
+# Lore
+
+The narrative substrate the cabinet operates inside. Code references this for
+naming, copy, and creative direction.
+
+## The Premise
+
+A general-purpose intelligence is failing. You are not playing the AI — you
+are the technician operating the rig that holds it together for one more
+shift. Every level is one episode of decoherence: the cognition spins,
+patterns leak out, you suppress what you can with the controls that emerge
+through the rim.
+
+The platter is not decoration. It is the literal substrate on which the
+intelligence runs. The sphere is not a sprite. It is the cognition itself
+under physical stress: calm and blue when coherent, hot and red when it is
+losing the plot. When coherence reaches zero, the glass shatters and the
+shift ends.
+
+There is no win condition, only **maintained coherence** — keep the cognition
+intact for as long as you can. The session ends when the sphere shatters, and
+a new shift begins.
+
+## The Cabinet Engine
+
+The cabinet itself is the world model. One chassis, many games:
+
+- **Industrial platter** — a heavy lathe-turned black-metal disc. Rim etched
+  with the operator directive ("MAINTAIN COHERENCE"). Holds the sphere in
+  its recess; rotates at a level-defined direction and speed; wobbles on the
+  X/Z axes as tension rises.
+- **Glass AI sphere** — recessed at platter centre. Outer shell is fragile
+  glass with subtle Fresnel; inner volume is a celestial nebula shader that
+  curdles from blue to red as tension climbs. Both shells hide on game-over;
+  shatter shards take their place.
+- **Rim slits** — recessed channels around the platter rim from which the
+  emergent controls rise on level start. Which controls rise tells the
+  player what game this is before any input is possible.
+- **Sky rain** — digital debris (rapier-driven cuboids) falls continuously
+  from above and impacts the sphere. Each impact pushes tension up. The rain
+  never stops; the rate scales with tension.
+- **Postprocess corruption** — chromatic aberration, scanlines, and screen
+  warp ramp with tension. The whole image degrades alongside the sphere.
+
+## Per-Level Variation
+
+Every level declares an `inputSchema: ControlSpec[]` on `Level`. The cabinet
+materialises matching controls through the rim:
+
+- **Pattern-match level** → N colored keycaps. Hold the matching key when a
+  pattern of that color escapes the sphere; the pull-back rate suppresses
+  it. Each suppression rewards coherence.
+- **Push/pull level** → paired handles with a `pairId`. Pull on one half,
+  push on the other to balance an internal pressure.
+- **Sequence level** → numbered keys to be pressed in a revealed order.
+- **Hybrid** → any combination.
+
+Adding a level is: (1) declare the `inputSchema`, (2) add a system in
+`src/sim/systems/` that consumes `Input.heldKeycaps` and mutates `Level`
+state, (3) optionally add a renderer in `src/three/` if it needs new visuals.
+The chassis (platter, sphere, rain, corruption) is reused.
+
+## Tone
+
+- **Industrial, deliberate, machined.** The cabinet was built by people for
+  whom the failing AI was either a job or a problem; never a toy.
+- **No celebration.** No score popups, no level-up fanfare, no congratulatory
+  copy. Coherence maintained = a quiet adjustment of the world. Coherence
+  lost = the glass breaks, the operator restarts the shift.
+- **Diegetic only.** Any text the player sees is etched, projected, or
+  emitted by the machine itself — the rim, the keycap faces, the corruption
+  overlay. Never a UI panel, never a HUD, never a tooltip.
+
+## Names that matter
+
+- **Coherence** — the variable the player is keeping above zero. Drains under
+  high tension.
+- **Tension** — the variable that ramps from rain impacts and pattern leaks.
+  Decays slowly toward a calm baseline (0.12) when undisturbed.
+- **The shift** — one play session, ends on shatter.
+- **The platter** — the substrate disc.
+- **The sphere** — the cognition.
+- **The rim** — the etched outer band; controls emerge through its slits.
+- **The rain** — falling debris from the sky above the cabinet.

--- a/src/three/cabinet.ts
+++ b/src/three/cabinet.ts
@@ -188,11 +188,6 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
   // to the DOM event for immediate reaction.
   window.addEventListener('gameOver', onGameOver);
 
-  // Reserved: track the last observed phase so we can react to transitions
-  // (e.g. play a whoosh sound when entering 'playing' from 'gameover').
-  // Currently unused — the shatter restore logic polls phase directly.
-  let _lastPhase: string | undefined = kootaWorld.get(Game)?.phase;
-
   const initialSchema = kootaWorld.get(Level)?.inputSchema ?? [];
   let emergentControls = createEmergentControls(scene, {
     schema: initialSchema,
@@ -304,7 +299,6 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
     // never set phase=gameover still recover cleanly.
     shatter.update();
     const phaseNow = kootaWorld.get(Game)?.phase;
-    _lastPhase = phaseNow;
     if (phaseNow === 'playing' && isShattered) {
       isShattered = false;
       shatter.reset();

--- a/src/three/cabinet.ts
+++ b/src/three/cabinet.ts
@@ -30,12 +30,13 @@ import {
   WebGLRenderer,
 } from 'three';
 import { RoomEnvironment } from 'three-stdlib';
-import { Input, Level } from '@/sim/world';
+import { Game, Input, Level } from '@/sim/world';
 import { type AICore, createAICore } from './ai-core';
 import { createEmergentControls, type EmergentControls } from './emergent-controls';
 import { createIndustrialPlatter, type IndustrialPlatter } from './industrial-platter';
 import { createPatternTrails, type PatternTrails } from './pattern-trails';
 import { CorruptionEffect } from './post-process-corruption';
+import { createShatter, type Shatter } from './shatter';
 import { createSkyRain, type SkyRain } from './sky-rain';
 
 export interface CabinetOptions {
@@ -53,6 +54,7 @@ export interface Cabinet {
   aiCore: AICore;
   skyRain: SkyRain;
   patternTrails: PatternTrails;
+  shatter: Shatter;
   /**
    * Current emergent-controls rig. Accessor (not bare property) because the
    * internal reference is swapped when Level.inputSchema changes — callers
@@ -94,9 +96,18 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
   const scene = new Scene();
   scene.background = new Color(0x0a0a0f);
 
-  const camera = new PerspectiveCamera(45, w / h, 0.1, 100);
-  camera.position.set(0, 1.8, 4.8);
-  camera.lookAt(0, -0.2, 0);
+  // Camera framing: classic arcade-cabinet three-quarter view. Low enough
+  // that the near half of the rim reads as a tall band (with etched text
+  // legible), elevated enough that you still see the top surface of the
+  // disc and the emerging keycaps. The sphere dominates the upper half
+  // of the frame.
+  //   - ~1.9m above the platter top surface
+  //   - ~5.2m back (more breathing room)
+  //   - Aimed slightly below the sphere so the rim text + platter top are
+  //     both visible with the sphere dominating the upper half.
+  const camera = new PerspectiveCamera(38, w / h, 0.1, 100);
+  camera.position.set(0, 1.9, 5.2);
+  camera.lookAt(0, 0.1, 0);
 
   // PMREM environment — procedural, no network.
   const pmrem = new PMREMGenerator(renderer);
@@ -159,6 +170,28 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
     floorY: -2.0,
   });
   const patternTrails = createPatternTrails(scene, kootaWorld);
+  const shatter = createShatter(scene, physics, { origin: new Vector3(0, 0.4, 0) });
+
+  // Listen for the gameOver event (dispatched by the tension driver). When
+  // coherence hits zero we detonate the shatter pool and hide the intact
+  // AI core so the shards are visibly replacing the glass sphere.
+  let isShattered = false;
+  function onGameOver(): void {
+    if (isShattered) return;
+    isShattered = true;
+    aiCore.outerMesh.visible = false;
+    aiCore.innerMesh.visible = false;
+    shatter.explode();
+  }
+  // Bundled with `gameover` phase change in the sim; the DOM event fires
+  // slightly earlier than the world state update (same frame). We listen
+  // to the DOM event for immediate reaction.
+  window.addEventListener('gameOver', onGameOver);
+
+  // Reserved: track the last observed phase so we can react to transitions
+  // (e.g. play a whoosh sound when entering 'playing' from 'gameover').
+  // Currently unused — the shatter restore logic polls phase directly.
+  let _lastPhase: string | undefined = kootaWorld.get(Game)?.phase;
 
   const initialSchema = kootaWorld.get(Level)?.inputSchema ?? [];
   let emergentControls = createEmergentControls(scene, {
@@ -264,6 +297,21 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
     // Pattern trails — read Koota pattern entities and draw.
     patternTrails.update();
 
+    // Shatter — only pushes body transforms when exploded. If the sim
+    // restart handler has moved us back to 'playing' after a shatter,
+    // restore the intact sphere. We check every frame instead of relying
+    // on a transition edge so programmatic resets via __fireGameOver that
+    // never set phase=gameover still recover cleanly.
+    shatter.update();
+    const phaseNow = kootaWorld.get(Game)?.phase;
+    _lastPhase = phaseNow;
+    if (phaseNow === 'playing' && isShattered) {
+      isShattered = false;
+      shatter.reset();
+      aiCore.outerMesh.visible = true;
+      aiCore.innerMesh.visible = true;
+    }
+
     // Emergent controls staggered emerge.
     if (emergeFn) {
       const elapsed = tNow - emergeStart;
@@ -291,6 +339,8 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
   }
 
   function dispose(): void {
+    window.removeEventListener('gameOver', onGameOver);
+    shatter.dispose();
     patternTrails.dispose();
     emergentControls.dispose();
     skyRain.dispose();
@@ -313,6 +363,7 @@ export async function createCabinet(opts: CabinetOptions): Promise<Cabinet> {
     aiCore,
     skyRain,
     patternTrails,
+    shatter,
     getEmergentControls: () => emergentControls,
     corruption,
     render,

--- a/src/three/shatter.ts
+++ b/src/three/shatter.ts
@@ -50,11 +50,15 @@ const TMP_QUAT = new Quaternion();
 const TMP_SCALE = new Vector3();
 const PARK_Y = -100;
 const SHARD_COLOR = new Color(0.35, 0.6, 1.0); // cold glass-blue
+const HIDDEN_COLOR = new Color(0, 0, 0);
+// Park matrix for hidden shards — composed once, reused across reset() calls.
+const PARK_MATRIX = new Matrix4().makeTranslation(0, PARK_Y, 0);
 
 export function createShatter(scene: Scene, physics: RAPIER.World, opts: ShatterOptions = {}): Shatter {
   const { origin = new Vector3(0, 0.4, 0), count = 48, burstSpeed = 5.5 } = opts;
 
-  const geometry = new BoxGeometry(0.08, 0.08, 0.08);
+  // Unit cube — per-shard `size` is applied via TMP_SCALE so visual matches collider.
+  const geometry = new BoxGeometry(1, 1, 1);
   const material = new MeshPhysicalMaterial({
     color: 0xaaccff,
     metalness: 0.1,
@@ -81,6 +85,9 @@ export function createShatter(scene: Scene, physics: RAPIER.World, opts: Shatter
 
   const shards: Shard[] = [];
   for (let i = 0; i < count; i++) {
+    // Pre-pick shard size so the collider half-extent matches the rendered scale.
+    const size = MathUtils.lerp(0.05, 0.12, Math.random());
+    const half = size * 0.5;
     const bodyDesc = RAPIER.RigidBodyDesc.dynamic()
       .setTranslation(0, PARK_Y, 0)
       .setGravityScale(0)
@@ -89,24 +96,18 @@ export function createShatter(scene: Scene, physics: RAPIER.World, opts: Shatter
       .setCanSleep(true);
     const body = physics.createRigidBody(bodyDesc);
     body.sleep();
-    const colliderDesc = RAPIER.ColliderDesc.cuboid(0.04, 0.04, 0.04)
+    const colliderDesc = RAPIER.ColliderDesc.cuboid(half, half, half)
       .setRestitution(0.5)
       .setFriction(0.4)
       .setDensity(0.3); // glass is light
     const collider = physics.createCollider(colliderDesc, body);
-    shards.push({ body, collider, color: SHARD_COLOR.clone(), size: 0.08 });
+    shards.push({ body, collider, color: SHARD_COLOR.clone(), size });
   }
 
   let exploded = false;
 
-  function writeInstance(i: number, visible: boolean): void {
+  function writeMatrix(i: number): void {
     const s = shards[i];
-    if (!visible) {
-      TMP_MATRIX.makeTranslation(0, PARK_Y, 0);
-      mesh.setMatrixAt(i, TMP_MATRIX);
-      mesh.setColorAt(i, new Color(0, 0, 0));
-      return;
-    }
     const pos = s.body.translation();
     const rot = s.body.rotation();
     TMP_POS.set(pos.x, pos.y, pos.z);
@@ -114,7 +115,11 @@ export function createShatter(scene: Scene, physics: RAPIER.World, opts: Shatter
     TMP_SCALE.setScalar(s.size);
     TMP_MATRIX.compose(TMP_POS, TMP_QUAT, TMP_SCALE);
     mesh.setMatrixAt(i, TMP_MATRIX);
-    mesh.setColorAt(i, s.color);
+  }
+
+  function parkInstance(i: number): void {
+    mesh.setMatrixAt(i, PARK_MATRIX);
+    mesh.setColorAt(i, HIDDEN_COLOR);
   }
 
   function explode(): void {
@@ -150,10 +155,10 @@ export function createShatter(scene: Scene, physics: RAPIER.World, opts: Shatter
         },
         true,
       );
-      s.size = MathUtils.lerp(0.05, 0.12, Math.random());
       s.body.setGravityScale(1, true);
       s.body.wakeUp();
-      writeInstance(i, true);
+      mesh.setColorAt(i, s.color);
+      writeMatrix(i);
     }
     mesh.instanceMatrix.needsUpdate = true;
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
@@ -168,16 +173,21 @@ export function createShatter(scene: Scene, physics: RAPIER.World, opts: Shatter
       s.body.setAngvel({ x: 0, y: 0, z: 0 }, false);
       s.body.setGravityScale(0, false);
       s.body.sleep();
-      writeInstance(i, false);
+      parkInstance(i);
     }
     mesh.instanceMatrix.needsUpdate = true;
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
   }
 
+  // Park all instances immediately so initial frames don't render uninitialized
+  // matrices as spurious unit cubes at the origin.
+  reset();
+
   function update(): void {
     if (!exploded) return;
+    // Colors are static after explode(); only rewrite matrices.
     for (let i = 0; i < count; i++) {
-      writeInstance(i, true);
+      writeMatrix(i);
     }
     mesh.instanceMatrix.needsUpdate = true;
   }

--- a/src/three/shatter.ts
+++ b/src/three/shatter.ts
@@ -1,0 +1,203 @@
+/**
+ * Shatter VFX — glass shards that spawn when the AI sphere fails.
+ *
+ * On game-over the AI core's intact glass sphere hides; a pool of small
+ * rapier-driven glass cuboids explodes outward with randomized angular
+ * velocity. Rain keeps falling, so the shards tumble with the debris —
+ * physically unified chaos. On restart, the pool is parked and the
+ * sphere returns.
+ *
+ * Pool size is fixed: 48 shards. We reuse bodies every restart so the
+ * rapier world doesn't grow unbounded across game-over cycles.
+ */
+
+import RAPIER from '@dimforge/rapier3d';
+import {
+  BoxGeometry,
+  Color,
+  InstancedMesh,
+  MathUtils,
+  Matrix4,
+  MeshPhysicalMaterial,
+  Quaternion,
+  type Scene,
+  Vector3,
+} from 'three';
+
+export interface ShatterOptions {
+  /** Center of the implosion — defaults to the AI core position. */
+  origin?: Vector3;
+  /** How many shards to spawn. */
+  count?: number;
+  /** Average outward burst velocity. */
+  burstSpeed?: number;
+}
+
+export interface Shatter {
+  mesh: InstancedMesh;
+  /** Detonate the pool — wake every shard with outward velocity. */
+  explode(): void;
+  /** Park every shard off-screen — call on restart. */
+  reset(): void;
+  /** Per-frame transform sync; no-op when not exploded. */
+  update(): void;
+  dispose(): void;
+}
+
+const TMP_MATRIX = new Matrix4();
+const TMP_POS = new Vector3();
+const TMP_QUAT = new Quaternion();
+const TMP_SCALE = new Vector3();
+const PARK_Y = -100;
+const SHARD_COLOR = new Color(0.35, 0.6, 1.0); // cold glass-blue
+
+export function createShatter(scene: Scene, physics: RAPIER.World, opts: ShatterOptions = {}): Shatter {
+  const { origin = new Vector3(0, 0.4, 0), count = 48, burstSpeed = 5.5 } = opts;
+
+  const geometry = new BoxGeometry(0.08, 0.08, 0.08);
+  const material = new MeshPhysicalMaterial({
+    color: 0xaaccff,
+    metalness: 0.1,
+    roughness: 0.2,
+    transmission: 0.6,
+    thickness: 0.05,
+    emissive: 0x112244,
+    emissiveIntensity: 0.3,
+    transparent: true,
+    opacity: 0.9,
+  });
+
+  const mesh = new InstancedMesh(geometry, material, count);
+  mesh.frustumCulled = false;
+  mesh.count = count;
+  scene.add(mesh);
+
+  interface Shard {
+    body: RAPIER.RigidBody;
+    collider: RAPIER.Collider;
+    color: Color;
+    size: number;
+  }
+
+  const shards: Shard[] = [];
+  for (let i = 0; i < count; i++) {
+    const bodyDesc = RAPIER.RigidBodyDesc.dynamic()
+      .setTranslation(0, PARK_Y, 0)
+      .setGravityScale(0)
+      .setLinearDamping(0.05)
+      .setAngularDamping(0.05)
+      .setCanSleep(true);
+    const body = physics.createRigidBody(bodyDesc);
+    body.sleep();
+    const colliderDesc = RAPIER.ColliderDesc.cuboid(0.04, 0.04, 0.04)
+      .setRestitution(0.5)
+      .setFriction(0.4)
+      .setDensity(0.3); // glass is light
+    const collider = physics.createCollider(colliderDesc, body);
+    shards.push({ body, collider, color: SHARD_COLOR.clone(), size: 0.08 });
+  }
+
+  let exploded = false;
+
+  function writeInstance(i: number, visible: boolean): void {
+    const s = shards[i];
+    if (!visible) {
+      TMP_MATRIX.makeTranslation(0, PARK_Y, 0);
+      mesh.setMatrixAt(i, TMP_MATRIX);
+      mesh.setColorAt(i, new Color(0, 0, 0));
+      return;
+    }
+    const pos = s.body.translation();
+    const rot = s.body.rotation();
+    TMP_POS.set(pos.x, pos.y, pos.z);
+    TMP_QUAT.set(rot.x, rot.y, rot.z, rot.w);
+    TMP_SCALE.setScalar(s.size);
+    TMP_MATRIX.compose(TMP_POS, TMP_QUAT, TMP_SCALE);
+    mesh.setMatrixAt(i, TMP_MATRIX);
+    mesh.setColorAt(i, s.color);
+  }
+
+  function explode(): void {
+    if (exploded) return;
+    exploded = true;
+    for (let i = 0; i < count; i++) {
+      const s = shards[i];
+      // Random position inside the sphere's volume.
+      const phi = Math.random() * Math.PI * 2;
+      const cosTheta = Math.random() * 2 - 1;
+      const sinTheta = Math.sqrt(1 - cosTheta * cosTheta);
+      const r = 0.15 + Math.random() * 0.35;
+      const x = origin.x + sinTheta * Math.cos(phi) * r;
+      const y = origin.y + cosTheta * r;
+      const z = origin.z + sinTheta * Math.sin(phi) * r;
+      s.body.setTranslation({ x, y, z }, true);
+      s.body.setRotation({ x: 0, y: 0, z: 0, w: 1 }, true);
+      // Outward burst from the sphere center + small upward bias.
+      const speed = burstSpeed * (0.7 + Math.random() * 0.6);
+      s.body.setLinvel(
+        {
+          x: sinTheta * Math.cos(phi) * speed,
+          y: cosTheta * speed + 1.2,
+          z: sinTheta * Math.sin(phi) * speed,
+        },
+        true,
+      );
+      s.body.setAngvel(
+        {
+          x: (Math.random() - 0.5) * 12,
+          y: (Math.random() - 0.5) * 12,
+          z: (Math.random() - 0.5) * 12,
+        },
+        true,
+      );
+      s.size = MathUtils.lerp(0.05, 0.12, Math.random());
+      s.body.setGravityScale(1, true);
+      s.body.wakeUp();
+      writeInstance(i, true);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }
+
+  function reset(): void {
+    exploded = false;
+    for (let i = 0; i < count; i++) {
+      const s = shards[i];
+      s.body.setTranslation({ x: 0, y: PARK_Y, z: 0 }, false);
+      s.body.setLinvel({ x: 0, y: 0, z: 0 }, false);
+      s.body.setAngvel({ x: 0, y: 0, z: 0 }, false);
+      s.body.setGravityScale(0, false);
+      s.body.sleep();
+      writeInstance(i, false);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }
+
+  function update(): void {
+    if (!exploded) return;
+    for (let i = 0; i < count; i++) {
+      writeInstance(i, true);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  function dispose(): void {
+    for (const s of shards) {
+      physics.removeCollider(s.collider, false);
+      physics.removeRigidBody(s.body);
+    }
+    scene.remove(mesh);
+    geometry.dispose();
+    material.dispose();
+    mesh.dispose();
+  }
+
+  return {
+    mesh,
+    explode,
+    reset,
+    update,
+    dispose,
+  };
+}


### PR DESCRIPTION
## Summary
Three landed together since they're all tied to the v4 cabinet identity:

- **Shatter VFX** (closes #68): rapier-driven 48-shard glass pool detonates
  when coherence hits zero. AI sphere meshes hide on gameOver, restored on
  phase→playing transition. Per-shard `size` is pre-picked at construction
  so each collider's half-extent matches its rendered scale.
- **Three-quarter camera** (closes #69): reframed to (0, 1.9, 5.2) lookAt
  (0, 0.1, 0) fov=38° — rim etching, platter top, and dominant sphere all
  visible.
- **Doc sweep + Cabinet Engine framing** (closes #52): README, CLAUDE.md,
  AGENTS.md, STANDARDS.md were still describing the retired Next.js +
  Babylon + Reactylon + Zustand + Miniplex stack. Rewrote each to match
  the v4 raw-three.js + rapier + Koota reality. New `docs/LORE.md`
  documents the Cabinet Engine: one chassis (platter, sphere, rain,
  corruption), per-level variation through `Level.inputSchema`.

Followups from CodeRabbit also addressed in this PR:
- Removed dead `_lastPhase` in cabinet.ts
- Replaced per-call `new Color(0,0,0)` and `makeTranslation` allocations in
  shatter.writeInstance with module-level reused constants
- Initial reset() at construction so uninitialised matrices don't render
- Removed redundant per-frame setColorAt in shatter.update

## Test plan
- [x] tsc, biome, vitest unit (24/24) all green
- [x] Visual verification: gameOver hides sphere, shards burst outward and tumble
- [x] Restart restores intact sphere
- [x] Three-quarter framing shows rim text + platter surface + dominant sphere

🤖 Generated with [Claude Code](https://claude.com/claude-code)