### PR TITLE
test: unit tests for tension-driver and pattern-stabilizer

### DIFF
--- a/src/sim/systems/__tests__/pattern-stabilizer.test.ts
+++ b/src/sim/systems/__tests__/pattern-stabilizer.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Game, Input, IsPattern, Level, Pattern, Position, world } from '@/sim/world';
+import { createPatternStabilizerState, tickPatternStabilizer } from '../pattern-stabilizer';
+
+const FIXED_STEP_S = 1 / 30;
+
+function resetWorld(): void {
+  world.set(Game, () => ({ phase: 'playing' as const, restartToken: 0 }));
+  world.set(Level, (prev) => ({
+    ...prev,
+    currentLevel: 1,
+    coherence: 25,
+    peakCoherence: 25,
+    tension: 0.12,
+  }));
+  world.set(Input, (prev) => ({ ...prev, heldKeycaps: new Set<number>() }));
+  // Destroy any leftover pattern entities from prior tests.
+  world.query(IsPattern).updateEach((_t, e) => {
+    e.destroy();
+  });
+}
+
+function spawnTestPattern(opts: { progress?: number; speed?: number; colorIndex?: number; angle?: number } = {}) {
+  const { progress = 0, speed = 0.5, colorIndex = 0, angle = 0 } = opts;
+  const e = world.spawn(IsPattern, Pattern, Position);
+  e.set(Pattern, { progress, speed, colorIndex, angle, color: '#ffffff' });
+  e.set(Position, { x: 0, y: 0.4, z: 0 });
+  return e;
+}
+
+describe('pattern-stabilizer', () => {
+  beforeEach(() => {
+    resetWorld();
+  });
+
+  it('does nothing and resets accumulator when phase is not playing', () => {
+    world.set(Game, (prev) => ({ ...prev, phase: 'paused' as const }));
+    const state = createPatternStabilizerState();
+    state.fixedStep.accumulator = 0.05;
+
+    tickPatternStabilizer(world, state, 0.5);
+
+    expect(state.fixedStep.accumulator).toBe(0);
+    expect(world.query(IsPattern).length).toBe(0);
+  });
+
+  it('advances pattern progress outward at its speed', () => {
+    const p = spawnTestPattern({ progress: 0.3, speed: 0.6 });
+
+    // Run one fixed step (1/30s).
+    const state = createPatternStabilizerState();
+    state.spawnTimer = 100; // suppress new spawns
+    tickPatternStabilizer(world, state, FIXED_STEP_S);
+
+    const data = p.get(Pattern);
+    expect(data?.progress).toBeCloseTo(0.3 + 0.6 * FIXED_STEP_S, 5);
+  });
+
+  it('pulls pattern progress back when the matching keycap is held', () => {
+    const p = spawnTestPattern({ progress: 0.5, speed: 0.6, colorIndex: 3 });
+    world.set(Input, (prev) => ({ ...prev, heldKeycaps: new Set<number>([3]) }));
+
+    const state = createPatternStabilizerState();
+    state.spawnTimer = 100;
+    tickPatternStabilizer(world, state, FIXED_STEP_S);
+
+    // forward: 0.6 * dt; pull: 2.4 * dt; net: -1.8 * dt = -0.06.
+    // 0.5 - 0.06 = 0.44. (forward applied first, then pull.)
+    const data = p.get(Pattern);
+    expect(data?.progress).toBeCloseTo(0.44, 5);
+  });
+
+  it('rewards coherence when a pattern is fully stabilised', () => {
+    const p = spawnTestPattern({ progress: 0.02, speed: 0, colorIndex: 1 });
+    world.set(Input, (prev) => ({ ...prev, heldKeycaps: new Set<number>([1]) }));
+
+    const state = createPatternStabilizerState();
+    state.spawnTimer = 100;
+    tickPatternStabilizer(world, state, FIXED_STEP_S);
+
+    expect(p.has(IsPattern)).toBe(false); // entity destroyed
+    expect(world.get(Level)?.coherence).toBeCloseTo(25 + 3, 5);
+  });
+
+  it('penalises tension when a pattern escapes (progress >= 1)', () => {
+    const p = spawnTestPattern({ progress: 0.99, speed: 1.0 });
+    const startTension = world.get(Level)?.tension ?? 0;
+
+    const state = createPatternStabilizerState();
+    state.spawnTimer = 100;
+    tickPatternStabilizer(world, state, FIXED_STEP_S);
+
+    expect(p.has(IsPattern)).toBe(false);
+    expect(world.get(Level)?.tension).toBeCloseTo(startTension + 0.12, 5);
+  });
+
+  it('clamps tension to 1 even with many escapes', () => {
+    for (let i = 0; i < 20; i++) {
+      spawnTestPattern({ progress: 0.99, speed: 1.0, angle: i });
+    }
+
+    const state = createPatternStabilizerState();
+    state.spawnTimer = 100;
+    tickPatternStabilizer(world, state, FIXED_STEP_S);
+
+    expect(world.get(Level)?.tension).toBe(1);
+  });
+
+  it('writes the pattern position from progress + angle', () => {
+    const p = spawnTestPattern({ progress: 0.5, speed: 0, angle: Math.PI / 2 });
+
+    const state = createPatternStabilizerState();
+    state.spawnTimer = 100;
+    tickPatternStabilizer(world, state, FIXED_STEP_S);
+
+    const pos = p.get(Position);
+    // angle = π/2, radius = 0.5 * 0.52 = 0.26 → x ≈ 0, z ≈ 0.26
+    expect(pos?.x).toBeCloseTo(0, 5);
+    expect(pos?.z).toBeCloseTo(0.26, 5);
+    expect(pos?.y).toBe(0.4);
+  });
+});

--- a/src/sim/systems/__tests__/tension-driver.test.ts
+++ b/src/sim/systems/__tests__/tension-driver.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Game, Level, world } from '@/sim/world';
+import { tickTensionDriver } from '../tension-driver';
+
+const TENSION_BASELINE = 0.12;
+
+function resetWorld(): void {
+  world.set(Game, () => ({ phase: 'playing' as const, restartToken: 0 }));
+  world.set(Level, (prev) => ({
+    ...prev,
+    currentLevel: 1,
+    coherence: 25,
+    peakCoherence: 25,
+    tension: TENSION_BASELINE,
+  }));
+}
+
+describe('tension-driver', () => {
+  beforeEach(() => {
+    resetWorld();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does nothing when phase is not playing', () => {
+    world.set(Game, (prev) => ({ ...prev, phase: 'title' as const }));
+    world.set(Level, (prev) => ({ ...prev, tension: 0.9, coherence: 50 }));
+
+    tickTensionDriver(world, 1.0);
+
+    const lvl = world.get(Level);
+    expect(lvl?.tension).toBe(0.9);
+    expect(lvl?.coherence).toBe(50);
+  });
+
+  it('drifts elevated tension back toward baseline over time', () => {
+    world.set(Level, (prev) => ({ ...prev, tension: 0.5 }));
+
+    tickTensionDriver(world, 1.0);
+
+    // IDLE_TENSION_DECAY = 0.04/s, so after 1s we move 0.04 toward 0.12 from 0.5 → 0.46.
+    expect(world.get(Level)?.tension).toBeCloseTo(0.46, 5);
+  });
+
+  it('drifts depressed tension back up toward baseline', () => {
+    world.set(Level, (prev) => ({ ...prev, tension: 0.04 }));
+
+    tickTensionDriver(world, 1.0);
+
+    // 0.04 + 0.04 = 0.08, still below baseline.
+    expect(world.get(Level)?.tension).toBeCloseTo(0.08, 5);
+  });
+
+  it('does not overshoot the baseline when drift is large', () => {
+    world.set(Level, (prev) => ({ ...prev, tension: 0.13 }));
+
+    tickTensionDriver(world, 10.0);
+
+    // Drift to baseline is 0.01; max possible step is 0.4. We must clamp.
+    expect(world.get(Level)?.tension).toBeCloseTo(TENSION_BASELINE, 5);
+  });
+
+  it('drains coherence when tension exceeds the high threshold', () => {
+    world.set(Level, (prev) => ({ ...prev, tension: 1.0, coherence: 50 }));
+
+    tickTensionDriver(world, 1.0);
+
+    // Decay runs first: 1.0 → 0.96. Drain uses the post-decay tension:
+    // overage = (0.96 - 0.75) / 0.25 = 0.84; drain = 2 * 0.84 * 1s = 1.68
+    // → coherence = 50 - 1.68 = 48.32
+    const lvl = world.get(Level);
+    expect(lvl?.tension).toBeCloseTo(0.96, 5);
+    expect(lvl?.coherence).toBeCloseTo(48.32, 5);
+  });
+
+  it('does not drain coherence when tension is at or below the threshold', () => {
+    world.set(Level, (prev) => ({ ...prev, tension: 0.75, coherence: 50 }));
+
+    tickTensionDriver(world, 1.0);
+
+    expect(world.get(Level)?.coherence).toBe(50);
+  });
+
+  it('advances level and resets coherence at 100', () => {
+    world.set(Level, (prev) => ({ ...prev, coherence: 100, currentLevel: 3 }));
+    const dispatched: CustomEvent[] = [];
+    const spy = vi.spyOn(window, 'dispatchEvent').mockImplementation((e) => {
+      dispatched.push(e as CustomEvent);
+      return true;
+    });
+
+    tickTensionDriver(world, 0.016);
+
+    const lvl = world.get(Level);
+    expect(lvl?.currentLevel).toBe(4);
+    expect(lvl?.coherence).toBe(25);
+    expect(lvl?.tension).toBe(TENSION_BASELINE);
+
+    const evt = dispatched.find((e) => e.type === 'coherenceMaintained');
+    expect(evt).toBeDefined();
+    expect((evt as CustomEvent).detail).toMatchObject({ level: 4 });
+
+    spy.mockRestore();
+  });
+
+  it('tracks peakCoherence as the running maximum', () => {
+    world.set(Level, (prev) => ({ ...prev, coherence: 80, peakCoherence: 60 }));
+
+    tickTensionDriver(world, 0.016);
+
+    expect(world.get(Level)?.peakCoherence).toBe(80);
+  });
+
+  it('triggers gameover and dispatches gameOver event when coherence hits zero', () => {
+    world.set(Level, (prev) => ({ ...prev, coherence: 1, tension: 1.0, currentLevel: 5, peakCoherence: 60 }));
+    const dispatched: CustomEvent[] = [];
+    const spy = vi.spyOn(window, 'dispatchEvent').mockImplementation((e) => {
+      dispatched.push(e as CustomEvent);
+      return true;
+    });
+
+    tickTensionDriver(world, 1.0);
+
+    const lvl = world.get(Level);
+    expect(lvl?.coherence).toBe(0);
+    expect(world.get(Game)?.phase).toBe('gameover');
+
+    const evt = dispatched.find((e) => e.type === 'gameOver');
+    expect(evt).toBeDefined();
+    expect((evt as CustomEvent).detail).toMatchObject({ peakCoherence: 60, currentLevel: 5 });
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
The two sim systems that own the gameplay loop had **no** test coverage. Both
are pure Koota mutations (no three.js, no rapier, no DOM rendering), so
they're trivially unit-testable — they just hadn't been.

Added 16 new tests across two files:

**tension-driver** — phase gating; bidirectional tension drift to baseline (with overshoot clamp); coherence drain only above HIGH_TENSION_THRESHOLD; level-advance + reset at coherence >= 100 with event dispatch; peakCoherence tracking; game-over trigger + event dispatch on coherence <= 0.

**pattern-stabilizer** — phase gating with accumulator reset; progress advance at speed * dt; pull-back math when matching keycap is held; coherence reward on stabilisation; tension penalty on escape; tension clamp to 1.0 with mass escapes; position write from progress + angle.

Brings unit coverage from 24 → 40 tests across 4 → 6 files. The systems are now safely refactorable, and the pinned-value assertions mean any future balance tuning runs explicitly through the test math (which lays groundwork for #40).

## Test plan
- [x] tsc, biome, vitest unit (40/40) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)