### PR TITLE
tune: balance pass 1 — bump stabilise reward + tension relief

### DIFF
--- a/src/sim/systems/__tests__/pattern-stabilizer.test.ts
+++ b/src/sim/systems/__tests__/pattern-stabilizer.test.ts
@@ -79,7 +79,8 @@ describe('pattern-stabilizer', () => {
     tickPatternStabilizer(world, state, FIXED_STEP_S);
 
     expect(p.has(IsPattern)).toBe(false); // entity destroyed
-    expect(world.get(Level)?.coherence).toBeCloseTo(25 + 3, 5);
+    // COHERENCE_REWARD = 4 (tuning pass 1)
+    expect(world.get(Level)?.coherence).toBeCloseTo(25 + 4, 5);
   });
 
   it('penalises tension when a pattern escapes (progress >= 1)', () => {

--- a/src/sim/systems/pattern-stabilizer.ts
+++ b/src/sim/systems/pattern-stabilizer.ts
@@ -20,8 +20,12 @@ import { Game, Input, IsPattern, Level, Pattern, Position, Seed } from '../world
 
 const FIXED_STEP_S = 1 / 30;
 const PATTERN_PULL_RATE = 2.4; // progress/sec pulled back when the matching keycap is held
-const COHERENCE_REWARD = 3; // per stabilised pattern
+const COHERENCE_REWARD = 4; // per stabilised pattern (tuning pass 1: 3 → 4)
 const TENSION_PENALTY = 0.12; // per escaped pattern
+// Per-stabilise tension drop (tuning pass 1: 0.05 → 0.08). Gives skilled
+// play meaningful tension clawback so a 0.95-tension state isn't a one-way
+// death spiral.
+const TENSION_RELIEF_PER_STABILISE = 0.08;
 const MAX_TENSION = 1;
 const MIN_TENSION = 0;
 
@@ -105,7 +109,7 @@ function runOneStep(world: World, state: PatternStabilizerState, dt: number): vo
         ...prev,
         coherence: nextCoh,
         peakCoherence: Math.max(prev.peakCoherence, nextCoh),
-        tension: Math.max(MIN_TENSION, prev.tension - stabilisedCount * 0.05),
+        tension: Math.max(MIN_TENSION, prev.tension - stabilisedCount * TENSION_RELIEF_PER_STABILISE),
       };
     });
   }


### PR DESCRIPTION
## Summary
Used the audit harness from #214 to print 30-second trajectories under three input policies. Found two flat curves:

1. **Perfect play levelled too slowly** — ORACLE took 26s to hit coherence 100. Felt unrewarding.
2. **Partial play saturated tension** — SLOW (holds key 0 half the time) hit 0.99 tension by 12s and never recovered. Crisis tension was a one-way trip.

### Two-knob tuning
- \`COHERENCE_REWARD\`: 3 → 4 per stabilised pattern
- New constant \`TENSION_RELIEF_PER_STABILISE\`: 0.05 → 0.08 per stabilised pattern (was a literal; promoted alongside \`COHERENCE_REWARD\` for future tuning to have one place to read)

### Measured effect (re-ran audit)
| Scenario | Before | After |
|---|---|---|
| ORACLE level-up | 26s | **19s** (27% faster) |
| SLOW @ 30s coherence | dead | **12–37 range, alive** |
| IDLE death | 21s | 21s (unchanged — failure mode preserved) |

Updated the one pinned unit-test value (25+3 → 25+4). All 4 audit scenarios still pass — they assert *shapes* of trajectories, not exact numbers.

Closes #40.

## Test plan
- [x] tsc, biome, vitest unit (44/44) green
- [x] Audit re-run shows the intended trajectory shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)